### PR TITLE
Dependencies: Update to zod-openapi 4.0.0

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -11,7 +11,7 @@
     "hono": "^4.6.4",
     "hono-openapi": "^0.1.5",
     "zod": "^3.23.8",
-    "zod-openapi": "^3.1.1"
+    "zod-openapi": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.17",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "hono": "^4.6.4",
     "@hono/zod-validator": "^0.4.1",
     "zod": "^3.23.8",
-    "zod-openapi": "^3.1.1",
+    "zod-openapi": "^4.0.0",
     "openapi-types": "^12.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The current version of hono-openapi depends on zod-openapi < 4.0.0. However, issue #3 resulted in a version bump of zod-openapi which fixes flattening of intersected zod schemas. Therefore, bump this package to use v4.0.0.

Tested with a simple server and nothing seems to be broken. Please take a look when possible @MathurAditya724 