### PR TITLE
Additional build changes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,10 +2,9 @@
   "name": "hono-openapi",
   "description": "OpenAPI schema generator for Hono",
   "version": "0.3.1",
-  "main": "./index.cjs",
-  "type": "module",
-  "module": "./index.js",
   "types": "./index.d.ts",
+  "main": "./index.js",
+  "type": "module",
   "license": "MIT",
   "keywords": [
     "hono",
@@ -54,34 +53,64 @@
   },
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "import": "./index.js",
-      "require": "./index.cjs"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "require": {
+        "types": "./index.d.cts",
+        "default": "./index.cjs"
+      }
     },
     "./zod": {
-      "types": "./zod.d.ts",
-      "import": "./zod.js",
-      "require": "./zod.cjs"
+      "import": {
+        "types": "./zod.d.ts",
+        "default": "./zod.js"
+      },
+      "require": {
+        "types": "./zod.d.cts",
+        "default": "./zod.cjs"
+      }
     },
     "./valibot": {
-      "types": "./valibot.d.ts",
-      "import": "./valibot.js",
-      "require": "./valibot.cjs"
+      "import": {
+        "types": "./valibot.d.ts",
+        "default": "./valibot.js"
+      },
+      "require": {
+        "types": "./valibot.d.cts",
+        "default": "./valibot.cjs"
+      }
     },
     "./typebox": {
-      "types": "./typebox.d.ts",
-      "import": "./typebox.js",
-      "require": "./typebox.cjs"
+      "import": {
+        "types": "./typebox.d.ts",
+        "default": "./typebox.js"
+      },
+      "require": {
+        "types": "./typebox.d.cts",
+        "default": "./typebox.cjs"
+      }
     },
     "./arktype": {
-      "types": "./arktype.d.ts",
-      "import": "./arktype.js",
-      "require": "./arktype.cjs"
+      "import": {
+        "types": "./arktype.d.ts",
+        "default": "./arktype.js"
+      },
+      "require": {
+        "types": "./arktype.d.cts",
+        "default": "./arktype.cjs"
+      }
     },
     "./effect": {
-      "types": "./effect.d.ts",
-      "import": "./effect.js",
-      "require": "./effect.cjs"
+      "import": {
+        "types": "./effect.d.ts",
+        "default": "./effect.js"
+      },
+      "require": {
+        "types": "./effect.d.cts",
+        "default": "./effect.cjs"
+      }
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "json-schema-walker": "^2.0.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@hono/arktype-validator": "^2.0.0",
     "@hono/effect-validator": "^1.2.0",
     "@hono/typebox-validator": "^0.2.0 || ^0.3.0",
@@ -45,6 +45,22 @@
     "valibot": "^1.0.0-beta.9",
     "zod": "^3.23.8",
     "zod-openapi": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@hono/arktype-validator": { "optional": true },
+    "@hono/effect-validator": { "optional": true },
+    "@hono/typebox-validator": { "optional": true },
+    "@hono/valibot-validator": { "optional": true },
+    "@hono/zod-validator": { "optional": true },
+    "@sinclair/typebox": { "optional": true },
+    "@valibot/to-json-schema": { "optional": true },
+    "arktype": { "optional": true },
+    "effect": { "optional": true },
+    "hono": { "optional": true },
+    "openapi-types": { "optional": true },
+    "valibot": { "optional": true },
+    "zod": { "optional": true },
+    "zod-openapi": { "optional": true }
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.3",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -2,7 +2,6 @@ import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import { defineConfig } from "rollup";
 import copy from "rollup-plugin-copy";
-import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   input: {
@@ -24,7 +23,6 @@ export default defineConfig({
       entryFileNames: "[name].cjs",
     },
   ],
-  external: Object.keys(pkg.optionalDependencies),
   plugins: [
     typescript({
       tsconfig: "./packages/core/tsconfig.lib.json",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -31,10 +31,16 @@ export default defineConfig({
     }),
     terser(),
     copy({
+      hook: "writeBundle",
       targets: [
         {
           src: ["./README.md", "./packages/core/package.json"],
           dest: "./packages/core/dist",
+        },
+        {
+          src: ["./packages/core/dist/*.d.ts"],
+          dest: "./packages/core/dist",
+          rename: (name, extension) => `${name}.c${extension}`,
         },
       ],
     }),

--- a/packages/core/src/arktype.ts
+++ b/packages/core/src/arktype.ts
@@ -1,13 +1,13 @@
 import { type Hook, arktypeValidator } from "@hono/arktype-validator";
 import type { Type } from "arktype";
 import type { Env, MiddlewareHandler, ValidationTargets } from "hono";
-import convert from "./toOpenAPISchema";
+import convert from "./toOpenAPISchema.js";
 import type {
   HasUndefined,
   OpenAPIRouteHandlerConfig,
   ResolverResult,
-} from "./types";
-import { generateValidatorDocs, uniqueSymbol } from "./utils";
+} from "./types.js";
+import { generateValidatorDocs, uniqueSymbol } from "./utils.js";
 
 /**
  * Generate a resolver for an Arktype schema

--- a/packages/core/src/effect.ts
+++ b/packages/core/src/effect.ts
@@ -6,13 +6,13 @@ import type {
   MiddlewareHandler,
   ValidationTargets,
 } from "hono";
-import convert from "./toOpenAPISchema";
+import convert from "./toOpenAPISchema.js";
 import type {
   HasUndefined,
   OpenAPIRouteHandlerConfig,
   ResolverResult,
-} from "./types";
-import { generateValidatorDocs, uniqueSymbol } from "./utils";
+} from "./types.js";
+import { generateValidatorDocs, uniqueSymbol } from "./utils.js";
 
 /**
  * Generate a resolver for an Effect schema

--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3 } from "openapi-types";
-import type { OpenAPIRoute } from "./types";
+import type { OpenAPIRoute } from "./types.js";
 
 export const ALLOWED_METHODS = [
   "GET",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
-export { describeRoute } from "./route";
-export { openAPISpecs, generateSpecs } from "./openapi";
-export type * from "./types";
+export { describeRoute } from "./route.js";
+export { openAPISpecs, generateSpecs } from "./openapi.js";
+export type * from "./types.js";

--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -6,14 +6,14 @@ import type {
   MiddlewareHandler,
 } from "hono/types";
 import type { OpenAPIV3 } from "openapi-types";
-import { ALLOWED_METHODS, filterPaths, registerSchemaPath } from "./helper";
+import { ALLOWED_METHODS, filterPaths, registerSchemaPath } from "./helper.js";
 import type {
   HandlerResponse,
   OpenAPIRoute,
   OpenAPIRouteHandlerConfig,
   OpenApiSpecsOptions,
-} from "./types";
-import { uniqueSymbol } from "./utils";
+} from "./types.js";
+import { uniqueSymbol } from "./utils.js";
 
 /**
  * Route handler for OpenAPI specs

--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -1,7 +1,10 @@
 import { HTTPException } from "hono/http-exception";
 import type { MiddlewareHandler } from "hono/types";
-import type { DescribeRouteOptions, OpenAPIRouteHandlerConfig } from "./types";
-import { uniqueSymbol } from "./utils";
+import type {
+  DescribeRouteOptions,
+  OpenAPIRouteHandlerConfig,
+} from "./types.js";
+import { uniqueSymbol } from "./utils.js";
 
 /**
  * Describe a route with OpenAPI specs.

--- a/packages/core/src/typebox.ts
+++ b/packages/core/src/typebox.ts
@@ -2,9 +2,9 @@ import { type Hook, tbValidator } from "@hono/typebox-validator";
 import type { Static, TSchema } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 import type { Env, MiddlewareHandler, ValidationTargets } from "hono";
-import convert from "./toOpenAPISchema";
-import type { OpenAPIRouteHandlerConfig, ResolverResult } from "./types";
-import { generateValidatorDocs, uniqueSymbol } from "./utils";
+import convert from "./toOpenAPISchema.js";
+import type { OpenAPIRouteHandlerConfig, ResolverResult } from "./types.js";
+import { generateValidatorDocs, uniqueSymbol } from "./utils.js";
 
 /**
  * Generate a resolver for a TypeBox schema

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 import type { Context, Env, Input } from "hono";
 import type { BlankInput } from "hono/types";
 import type { OpenAPIV3 } from "openapi-types";
-import type { ALLOWED_METHODS } from "./helper";
+import type { ALLOWED_METHODS } from "./helper.js";
 
 export type HasUndefined<T> = undefined extends T ? true : false;
 export type PromiseOr<T> = T | Promise<T>;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import type { ValidationTargets } from "hono";
 import type { OpenAPIV3 } from "openapi-types";
-import type { ResolverResult } from "./types";
+import type { ResolverResult } from "./types.js";
 
 export const uniqueSymbol = Symbol("openapi");
 

--- a/packages/core/src/valibot.ts
+++ b/packages/core/src/valibot.ts
@@ -15,13 +15,13 @@ import {
   type InferOutput,
   parseAsync,
 } from "valibot";
-import convert from "./toOpenAPISchema";
+import convert from "./toOpenAPISchema.js";
 import type {
   HasUndefined,
   OpenAPIRouteHandlerConfig,
   ResolverResult,
-} from "./types";
-import { generateValidatorDocs, uniqueSymbol } from "./utils";
+} from "./types.js";
+import { generateValidatorDocs, uniqueSymbol } from "./utils.js";
 
 /**
  * Generate a resolver for a Valibot schema

--- a/packages/core/src/zod.ts
+++ b/packages/core/src/zod.ts
@@ -6,8 +6,8 @@ import type {
   HasUndefined,
   OpenAPIRouteHandlerConfig,
   ResolverResult,
-} from "./types";
-import { generateValidatorDocs, uniqueSymbol } from "./utils";
+} from "./types.js";
+import { generateValidatorDocs, uniqueSymbol } from "./utils.js";
 
 /**
  * Generate a resolver for a Zod schema

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -7,7 +7,8 @@
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "declarationMap": false,
-    "module": "ESNext",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,10 +138,6 @@ importers:
 
   packages/core:
     dependencies:
-      json-schema-walker:
-        specifier: ^2.0.0
-        version: 2.0.0
-    optionalDependencies:
       '@hono/arktype-validator':
         specifier: ^2.0.0
         version: 2.0.0(arktype@2.0.0-rc.30)(hono@4.6.14)
@@ -172,6 +168,9 @@ importers:
       hono:
         specifier: ^4.6.13
         version: 4.6.14
+      json-schema-walker:
+        specifier: ^2.0.0
+        version: 2.0.0
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -5672,13 +5671,11 @@ snapshots:
     dependencies:
       arktype: 2.0.0-rc.30
       hono: 4.6.14
-    optional: true
 
   '@hono/effect-validator@1.2.0(effect@3.12.0)(hono@4.6.14)':
     dependencies:
       effect: 3.12.0
       hono: 4.6.14
-    optional: true
 
   '@hono/node-server@1.13.7(hono@4.6.14)':
     dependencies:
@@ -5694,13 +5691,11 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.13
       hono: 4.6.14
-    optional: true
 
   '@hono/valibot-validator@0.5.1(hono@4.6.14)(valibot@1.0.0-beta.9(typescript@5.7.2))':
     dependencies:
       hono: 4.6.14
       valibot: 1.0.0-beta.9(typescript@5.7.2)
-    optional: true
 
   '@hono/zod-validator@0.4.2(hono@4.6.14)(zod@3.24.1)':
     dependencies:
@@ -6302,7 +6297,6 @@ snapshots:
   '@valibot/to-json-schema@1.0.0-beta.3(valibot@1.0.0-beta.9(typescript@5.7.2))':
     dependencies:
       valibot: 1.0.0-beta.9(typescript@5.7.2)
-    optional: true
 
   '@verdaccio/auth@8.0.0-next-8.1':
     dependencies:
@@ -8268,8 +8262,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openapi-types@12.1.3:
-    optional: true
+  openapi-types@12.1.3: {}
 
   opener@1.5.2: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
-    "composite": true,
+    "composite": false,
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
- use optional peerDependencies. This is the only way to make dependencies truly opt-in with package.json
- rework exports in package.json as discussed in issue
- use rollup plugin to copy declaration files after bundling

Note: This is still not working according to are the types wrong. You can run `npx --yes @arethetypeswrong/cli --pack ./packages/core/dist` in the repo and it will tell you the issues. I believe the issues come from missing file extensions in the import paths of the emitted files. This could probably be solved by changing the base tsconfig of the repo to "nodenext" instead of "bundler" and then fix all the errors tsc reports. But I'm not entirely sure. At this point, I think I would give tsup a try because there is a good chance it solve most of the remaining issues automatically.