### PR TITLE
feat(core): Add the cause of validation error to HTTPException

### DIFF
--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -43,6 +43,7 @@ export function describeRoute(specs: DescribeRouteOptions): MiddlewareHandler {
             } catch (error) {
               throw new HTTPException(400, {
                 message: "Response validation failed!",
+                cause: error,
               });
             }
           }


### PR DESCRIPTION
Heya!

I noticed that while adding the `validateResponse` -flag to the `describeRoute` does in fact validate the response, it does not report in any way, what the errors were. This makes debugging faulty response schemas extremely difficult.

We have the error in scope, so this PR adds them to the response's cause, which is just empty otherwise.

Then the user could opt in on how they want to manage the cause, e.g:

```typescript
app.onError((err, c) => {
    if (err instanceof HTTPException) {
        if (err.status === 400) {
            return new Response(err.cause, {
                status: 400,
                headers: err.res?.headers,
            });
        }

        return err.getResponse();
    }
});
```

```json
[
  {
    "code": "invalid_type",
    "expected": "date",
    "received": "string",
    "path": [
      "pastEvents",
      0,
      "startTime"
    ],
    "message": "Expected date, received string"
  },
  {
    "code": "invalid_type",
    "expected": "date",
    "received": "string",
    "path": [
      "pastEvents",
      0,
      "endTime"
    ],
    "message": "Expected date, received string"
  }
]
```