### PR TITLE
fix(core/toOpenAPISchema): "`anyOf` enum schema is lost" attempt

### DIFF
--- a/packages/core/src/toOpenAPISchema.ts
+++ b/packages/core/src/toOpenAPISchema.ts
@@ -359,7 +359,7 @@ function convertExamples(schema: SchemaType) {
 }
 
 function rewriteConst(schema: SchemaType) {
-  if (Object.hasOwnProperty.call(schema, "const")) {
+  if (!Object.hasOwnProperty.call(schema, "enum") && Object.hasOwnProperty.call(schema, "const")) {
     schema.enum = [schema.const];
     schema.const = undefined;
   }

--- a/packages/core/src/toOpenAPISchema.ts
+++ b/packages/core/src/toOpenAPISchema.ts
@@ -359,7 +359,7 @@ function convertExamples(schema: SchemaType) {
 }
 
 function rewriteConst(schema: SchemaType) {
-  if (!Object.hasOwnProperty.call(schema, "enum") && Object.hasOwnProperty.call(schema, "const")) {
+  if (typeof schema.const !== 'undefined') {
     schema.enum = [schema.const];
     schema.const = undefined;
   }


### PR DESCRIPTION
Fixes #52.

This PR avoids running unnecessary `rewriteConst` if `enum` property already exists, this also fixes #52, #52 seems be caused because a property path could be walked through by `json-schema-walker` multiple times.