### PR TITLE
fix(core): support arktype transform

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -9,7 +9,7 @@
     "@hono/zod-validator": "^0.4.2",
     "@scalar/hono-api-reference": "^0.5.165",
     "@sinclair/typebox": "^0.34.13",
-    "arktype": "^2.0.0-rc.30",
+    "arktype": "^2.0.0",
     "effect": "^3.12.0",
     "hono": "^4.6.14",
     "hono-openapi": "0.3.0",

--- a/apps/sandbox/src/routes/arktype.ts
+++ b/apps/sandbox/src/routes/arktype.ts
@@ -53,7 +53,7 @@ router.post(
   aValidator(
     "json",
     type({
-      id: "number",
+      id: "number | string.numeric.parse",
     }),
   ),
   (c) => {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/node": "18.16.9",
     "@vitest/coverage-v8": "^1.6.0",
     "@vitest/ui": "^1.6.0",
-    "arktype": "^2.0.0-rc.30",
+    "arktype": "^2.0.0",
     "czg": "^1.11.0",
     "husky": "^9.1.7",
     "is-ci": "^4.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@hono/zod-validator": "^0.4.1",
     "@sinclair/typebox": "^0.34.9",
     "@valibot/to-json-schema": "^1.0.0-beta.3",
-    "arktype": "^2.0.0-rc.25",
+    "arktype": "^2.0.0",
     "effect": "^3.11.3",
     "hono": "^4.6.13",
     "openapi-types": "^12.1.3",

--- a/packages/core/src/arktype.ts
+++ b/packages/core/src/arktype.ts
@@ -17,7 +17,7 @@ import { generateValidatorDocs, uniqueSymbol } from "./utils.js";
 export function resolver<T extends Type>(schema: T): ResolverResult {
   return {
     builder: async () => ({
-      schema: await convert(schema.toJsonSchema()),
+      schema: await convert(schema.in.toJsonSchema()),
     }),
     validator: (value) => {
       schema.assert(value);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^0.34.13
         version: 0.34.13
       arktype:
-        specifier: ^2.0.0-rc.30
-        version: 2.0.0-rc.33
+        specifier: ^2.0.0
+        version: 2.1.16
       effect:
         specifier: ^3.12.0
         version: 3.12.0
@@ -223,12 +223,6 @@ packages:
     dev: false
     optional: true
 
-  /@ark/schema@0.33.0:
-    resolution: {integrity: sha512-GPjzbiydOL5gd9UFZMUQr5JBqT9YTX2dPT+u18aNswlGOgQE01y9B6kiwK/JyoaSwEJSDyxAPABsVRL7gG9KSQ==}
-    dependencies:
-      '@ark/util': 0.33.0
-    dev: false
-
   /@ark/schema@0.45.6:
     resolution: {integrity: sha512-uI/z6kAabOKeFxbJK2w26dD0FZLutL0LTw0o3EZsX+UC4exc34YUVkm7/wuUMvc5Z27IVDjoaZp9o7X4jOFAbg==}
     dependencies:
@@ -239,10 +233,6 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
-
-  /@ark/util@0.33.0:
-    resolution: {integrity: sha512-zzYQiRHLPwK15T5CM6SgQXTycKNpAvA2qwdlMbK5vFbLzy3P87VNKA8NiezBIXm+jsov3lEtMKE6kLtbZQDUbg==}
-    dev: false
 
   /@ark/util@0.45.6:
     resolution: {integrity: sha512-eI8Y1X0+271Q1p8qU39tkyrzIVMZIuymzixzVD0UL7k+HJaPhbbrjuKW/1CZzQ64tc+ugl7z2kP01YlAMA5h7A==}
@@ -4130,13 +4120,6 @@ packages:
       '@ark/util': 0.25.0
     dev: false
     optional: true
-
-  /arktype@2.0.0-rc.33:
-    resolution: {integrity: sha512-ndtDXtunbff0o1urOOXq/eHGuUqIlp5MZ99lWON3MS0LZzF7/WFf+SwOCSomoPj9BptMLMyLS9cIYVNndD5QVQ==}
-    dependencies:
-      '@ark/schema': 0.33.0
-      '@ark/util': 0.33.0
-    dev: false
 
   /arktype@2.1.16:
     resolution: {integrity: sha512-KEuoEtpmbNVAIZqyLE+ox4Ga/6ED7Oe3Ra90sxGe4ZnufLz8AH49Xqis0i6oNEq23KmpduRLZRfS+iTAkjnfDw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(vitest@2.1.8)
       arktype:
-        specifier: ^2.0.0-rc.30
-        version: 2.0.0-rc.33
+        specifier: ^2.0.0
+        version: 2.1.16
       czg:
         specifier: ^1.11.0
         version: 1.11.0
@@ -143,7 +143,7 @@ importers:
     dependencies:
       '@hono/arktype-validator':
         specifier: ^2.0.0
-        version: 2.0.0(arktype@2.0.0-rc.33)(hono@4.6.14)
+        version: 2.0.0(arktype@2.1.16)(hono@4.6.14)
       '@hono/effect-validator':
         specifier: ^1.2.0
         version: 1.2.0(effect@3.12.0)(hono@4.6.14)
@@ -163,8 +163,8 @@ importers:
         specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(valibot@1.0.0-beta.9)
       arktype:
-        specifier: ^2.0.0-rc.25
-        version: 2.0.0-rc.33
+        specifier: ^2.0.0
+        version: 2.1.16
       effect:
         specifier: ^3.11.3
         version: 3.12.0
@@ -227,6 +227,12 @@ packages:
     resolution: {integrity: sha512-GPjzbiydOL5gd9UFZMUQr5JBqT9YTX2dPT+u18aNswlGOgQE01y9B6kiwK/JyoaSwEJSDyxAPABsVRL7gG9KSQ==}
     dependencies:
       '@ark/util': 0.33.0
+    dev: false
+
+  /@ark/schema@0.45.6:
+    resolution: {integrity: sha512-uI/z6kAabOKeFxbJK2w26dD0FZLutL0LTw0o3EZsX+UC4exc34YUVkm7/wuUMvc5Z27IVDjoaZp9o7X4jOFAbg==}
+    dependencies:
+      '@ark/util': 0.45.6
 
   /@ark/util@0.25.0:
     resolution: {integrity: sha512-yo2Me+tYnmr6E0E3maZzu643/rL07oR25yBHkH24gllssqYcd6EPCvZE23GEKgbk0iac9J73GlJ9pkgZj43Q2g==}
@@ -236,6 +242,10 @@ packages:
 
   /@ark/util@0.33.0:
     resolution: {integrity: sha512-zzYQiRHLPwK15T5CM6SgQXTycKNpAvA2qwdlMbK5vFbLzy3P87VNKA8NiezBIXm+jsov3lEtMKE6kLtbZQDUbg==}
+    dev: false
+
+  /@ark/util@0.45.6:
+    resolution: {integrity: sha512-eI8Y1X0+271Q1p8qU39tkyrzIVMZIuymzixzVD0UL7k+HJaPhbbrjuKW/1CZzQ64tc+ugl7z2kP01YlAMA5h7A==}
 
   /@babel/code-frame@7.26.2:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -2168,14 +2178,14 @@ packages:
     dev: false
     optional: true
 
-  /@hono/arktype-validator@2.0.0(arktype@2.0.0-rc.33)(hono@4.6.14):
+  /@hono/arktype-validator@2.0.0(arktype@2.1.16)(hono@4.6.14):
     resolution: {integrity: sha512-ICNZrK6Qcw6gyPfW53ONXI4JomRcks0fQhqzn9EWsfr6nlL6BNXQ96vIgVDU8qimcbJ2m3GJFAqgzOvWbZk3jw==}
     requiresBuild: true
     peerDependencies:
       arktype: ^2.0.0-dev.14
       hono: '*'
     dependencies:
-      arktype: 2.0.0-rc.33
+      arktype: 2.1.16
       hono: 4.6.14
     dev: false
 
@@ -4126,6 +4136,13 @@ packages:
     dependencies:
       '@ark/schema': 0.33.0
       '@ark/util': 0.33.0
+    dev: false
+
+  /arktype@2.1.16:
+    resolution: {integrity: sha512-KEuoEtpmbNVAIZqyLE+ox4Ga/6ED7Oe3Ra90sxGe4ZnufLz8AH49Xqis0i6oNEq23KmpduRLZRfS+iTAkjnfDw==}
+    dependencies:
+      '@ark/schema': 0.45.6
+      '@ark/util': 0.45.6
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}


### PR DESCRIPTION
arktype morph(transform)

```ts
type("string.numeric.parse") // or type("string").pipe(Number)
```

It will throw this error message, like #72

```log
error: (In: string) => Out<unknown> is not convertible to JSON Schema because it represents a transformation, while JSON Schema only allows validation. Consider creating a Schema from one of its endpoints using `.in` or `.out`.
```

`2.0.0-rc.xx` does not seem to include the `Type.in.toJsonSchema` type.
I updated to `2.0.0`.