### PR TITLE
docs: update Scalar example in README.md to newer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,9 @@ Now, you can access the OpenAPI specification by visiting `http://localhost:3000
 ```ts
 app.get(
   "/docs",
-  apiReference({
+  Scalar({
     theme: "saturn",
-    spec: {
-      url: "/openapi",
-    },
+    url: "/openapi",
   })
 );
 ```


### PR DESCRIPTION
The apiReference function in Scalar has been deprecated, and using the Scalar function would provide a better example.

https://github.com/scalar/scalar/blob/3e4a7f5a24e9fae36f157e0d71575f6cdb2c2a13/integrations/hono/src/scalar.ts#L133
