### PR TITLE
fix(core): Ensure only unique tags are generated

### DIFF
--- a/packages/core/src/__tests__/core.spec.ts
+++ b/packages/core/src/__tests__/core.spec.ts
@@ -208,4 +208,86 @@ describe("describeRoute with .use", () => {
       },
     });
   });
+
+  it("should generate unique tags", async () => {
+    const app = new Hono()
+      .use(
+        describeRoute({
+          tags: ["test"],
+          responses: {
+            "400": {
+              description: "Bad Request",
+              content: {
+                "text/plain": {
+                  schema: resolver(z.string()),
+                },
+              },
+            },
+          },
+        }),
+      )
+      .get(
+        "/",
+        describeRoute({
+          tags: ["test"],
+          responses: {
+            "200": {
+              description: "OK",
+              content: {
+                "text/plain": {
+                  schema: resolver(z.string()),
+                },
+              },
+            },
+          },
+        }),
+        validator("param", z.object({ id: z.string() })),
+        (c) => {
+          return c.text("Hello");
+        },
+      );
+
+    const result = await generateSpecs(app);
+
+    const path = result.paths["/"];
+
+    expect(path).toEqual({
+      get: {
+        operationId: "getIndex",
+        tags: ["test"],
+        parameters: [
+          {
+            name: "id",
+            in: "param",
+            required: true,
+            schema: {
+              type: "string",
+            },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "text/plain": {
+                schema: {
+                  type: "string",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "text/plain": {
+                schema: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -78,10 +78,12 @@ function mergeRouteData(...data: (OpenAPIRoute["data"] | undefined)[]) {
 
     let tags: DescribeRouteOptions["tags"] = undefined;
     if (("tags" in acc && acc.tags) || ("tags" in route && route.tags)) {
-      tags = [
-        ...getProperty(acc, "tags", []),
-        ...getProperty(route, "tags", []),
-      ];
+      tags = Array.from(
+        new Set([
+          ...getProperty(acc, "tags", []),
+          ...getProperty(route, "tags", []),
+        ]),
+      );
     }
 
     return {


### PR DESCRIPTION
The `generateSpecs` can generate OpenApi specs with repeated values for the same tag, especially when `describeRoute` is used as a middleware.

Here's a snapshot of the added test without the fix:
``` json
{
  "get": {
    "operationId": "getIndex",
    "parameters": [
      {
        "in": "param",
        "name": "id",
        "required": true,
        "schema": {
          "type": "string",
        },
      },
    ],
    "responses": {
      "200": {
        "content": {
          "text/plain": {
            "schema": {
              "type": "string",
            },
          },
        },
        "description": "OK",
      },
      "400": {
        "content": {
          "text/plain": {
            "schema": {
              "type": "string",
            },
          },
        },
        "description": "Bad Request",
      },
    },
    "tags": [
      "test",
      "test", // value generated twice because of describeRoute as middleware 
      "test", // third time for the tag added to `.get` route
    ],
  },
}
```