### PR TITLE
Keep top-level fields in `mergeParameters` 

### DIFF
--- a/packages/core/src/__tests__/core.spec.ts
+++ b/packages/core/src/__tests__/core.spec.ts
@@ -70,6 +70,8 @@ describe("parameters should be merged", () => {
           {
             name: "id",
             in: "param",
+            description: "The ID of the item",
+            example: "4daec17a-9ed2-40d2-b577-22bb89b96071",
             required: true,
             schema: {
               type: "string",
@@ -88,6 +90,8 @@ describe("parameters should be merged", () => {
       {
         name: "id",
         in: "param",
+        description: "The ID of the item",
+        example: "4daec17a-9ed2-40d2-b577-22bb89b96071",
         required: true,
         schema: {
           type: "string",

--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -82,7 +82,7 @@ function mergeRouteData(...data: OpenAPIRoute["data"][]) {
   return data.reduce<NonNullable<OpenAPIRoute["data"]>>((acc, route) => {
     if (!route) return acc;
 
-    let tags: DescribeRouteOptions["tags"] = undefined;
+    let tags: DescribeRouteOptions["tags"];
     if (("tags" in acc && acc.tags) || ("tags" in route && route.tags)) {
       tags = Array.from(
         new Set([
@@ -169,7 +169,17 @@ function mergeParameters(...params: (Parameter[] | undefined)[]): Parameter[] {
   const _params = params.flatMap((x) => x ?? []);
 
   const merged = _params.reduce((acc, param) => {
-    acc.set(paramKey(param), param);
+    const key = paramKey(param);
+    const existing = acc.get(key);
+    if (!existing) {
+      acc.set(paramKey(param), param);
+    } else {
+      // shallow merge
+      acc.set(key, {
+        ...existing,
+        ...param,
+      });
+    }
     return acc;
   }, new Map<string, Parameter>());
 


### PR DESCRIPTION
Hello there, thank you for the good work. I'm trying to use `describeRoute` to provide detailed OpenAPI docs that [describe parameters](https://swagger.io/docs/specification/v3_0/describing-parameters/#path-parameters), but noticed the current implementation of `mergeParameters` as of `0.4.8` effectively keeps the last parameter instead of 'merging' them:

https://github.com/rhinobase/hono-openapi/blob/c166811df2c1b34f821575e38046ce61c175f88b/packages/core/src/helper.ts#L171-L174

This PR adjusts to shallow merge first level properties. I don't think recursive merge is necessary. Also, if there is a reason behind the current implementation, pardon me for my ignorance, would love to understand it better.

> [!NOTE]
> I don't find any reference in [CONTRIBUTING](https://github.com/rhinobase/hono-openapi/blob/main/CONTRIBUTING.md) for versioning, so let me know if you want me to bump version in `package.json`.

Thanks!