### PR TITLE
[next] Keep top-level fields in mergeParameters

### DIFF
--- a/src/__tests__/__snapshots__/arktype.test.ts.snap
+++ b/src/__tests__/__snapshots__/arktype.test.ts.snap
@@ -12,11 +12,36 @@ exports[`arktype > basic 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
-    "/": {
+    "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "GETIndex",
-        "parameters": [],
+        "operationId": "GET:id",
+        "parameters": [
+          {
+            "description": "The ID of the item",
+            "example": "4daec17a-9ed2-40d2-b577-22bb89b96071",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "description": "The category of the item",
+            "example": "one",
+            "in": "query",
+            "name": "category",
+            "required": undefined,
+            "schema": {
+              "enum": [
+                "one",
+                "three",
+                "two",
+              ],
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/__tests__/__snapshots__/effect.test.ts.snap
+++ b/src/__tests__/__snapshots__/effect.test.ts.snap
@@ -12,11 +12,37 @@ exports[`effect > basic 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
-    "/": {
+    "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "GETIndex",
-        "parameters": [],
+        "operationId": "GET:id",
+        "parameters": [
+          {
+            "description": "The ID of the item",
+            "example": "4daec17a-9ed2-40d2-b577-22bb89b96071",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "description": "The category of the item",
+            "example": "one",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "enum": [
+                "one",
+                "two",
+                "three",
+              ],
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/__tests__/__snapshots__/valibot.test.ts.snap
+++ b/src/__tests__/__snapshots__/valibot.test.ts.snap
@@ -12,11 +12,36 @@ exports[`valibot > basic 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
-    "/": {
+    "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "GETIndex",
-        "parameters": [],
+        "operationId": "GET:id",
+        "parameters": [
+          {
+            "description": "The ID of the item",
+            "example": "4daec17a-9ed2-40d2-b577-22bb89b96071",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "description": "The category of the item",
+            "example": "one",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "enum": [
+                "one",
+                "two",
+                "three",
+              ],
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/__tests__/__snapshots__/zodv3.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv3.test.ts.snap
@@ -12,11 +12,37 @@ exports[`zod v3 > basic 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
-    "/": {
+    "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "GETIndex",
-        "parameters": [],
+        "operationId": "GET:id",
+        "parameters": [
+          {
+            "description": "The ID of the item",
+            "example": "4daec17a-9ed2-40d2-b577-22bb89b96071",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "description": "The category of the item",
+            "example": "one",
+            "in": "query",
+            "name": "category",
+            "required": undefined,
+            "schema": {
+              "enum": [
+                "one",
+                "two",
+                "three",
+              ],
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/__tests__/__snapshots__/zodv4.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv4.test.ts.snap
@@ -12,11 +12,37 @@ exports[`zod v4 > basic 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
-    "/": {
+    "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "GETIndex",
-        "parameters": [],
+        "operationId": "GET:id",
+        "parameters": [
+          {
+            "description": "The ID of the item",
+            "example": "4daec17a-9ed2-40d2-b577-22bb89b96071",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "description": "The category of the item",
+            "example": "one",
+            "in": "query",
+            "name": "category",
+            "required": undefined,
+            "schema": {
+              "enum": [
+                "one",
+                "two",
+                "three",
+              ],
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/__tests__/arktype.test.ts
+++ b/src/__tests__/arktype.test.ts
@@ -3,31 +3,24 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { generateSpecs } from "../handler.js";
 import { describeRoute, resolver, validator } from "../middlewares.js";
+import { defineCommonTestRouteSpec } from "./utils/route.js";
 
 describe("arktype", () => {
   it("basic", async () => {
     const app = new Hono().get(
-      "/",
-      describeRoute({
-        tags: ["test"],
-        summary: "Test route",
-        description: "This is a test route",
-        responses: {
-          200: {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  type({
-                    message: "string",
-                  }),
-                ),
-              },
-            },
-          },
-        },
-      }),
+      "/:id",
+      describeRoute(
+        defineCommonTestRouteSpec(
+          resolver(
+            type({
+              message: "string",
+            }),
+          ),
+        ),
+      ),
+      validator("param", type({ id: "string" })),
       validator("json", type({ message: "string" })),
+      validator('query', type({ "category?": "'one' | 'two' | 'three'" })),
       async (c) => {
         return c.json({ message: "Hello, world!" });
       },

--- a/src/__tests__/effect.test.ts
+++ b/src/__tests__/effect.test.ts
@@ -3,32 +3,39 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { generateSpecs } from "../handler.js";
 import { describeRoute, resolver, validator } from "../middlewares.js";
+import { defineCommonTestRouteSpec } from "./utils/route.js";
 
 describe("effect", () => {
   it("basic", async () => {
     const app = new Hono().get(
-      "/",
-      describeRoute({
-        tags: ["test"],
-        summary: "Test route",
-        description: "This is a test route",
-        responses: {
-          200: {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  Schema.standardSchemaV1(
-                    Schema.Struct({
-                      message: Schema.String,
-                    }),
-                  ),
-                ),
-              },
-            },
-          },
-        },
-      }),
+      "/:id",
+      describeRoute(
+        defineCommonTestRouteSpec(
+          resolver(
+            Schema.standardSchemaV1(
+              Schema.Struct({
+                message: Schema.String,
+              }),
+            ),
+          ),
+        ),
+      ),
+      validator(
+        "param",
+        Schema.standardSchemaV1(Schema.Struct({ id: Schema.String })),
+      ),
+      validator(
+        "query",
+        Schema.standardSchemaV1(
+          Schema.Struct({
+            category: Schema.Union(
+              Schema.Literal("one"),
+              Schema.Literal("two"),
+              Schema.Literal("three"),
+            ).pipe(Schema.optional),
+          }),
+        ),
+      ),
       validator(
         "json",
         Schema.standardSchemaV1(

--- a/src/__tests__/utils/route.ts
+++ b/src/__tests__/utils/route.ts
@@ -1,0 +1,40 @@
+import type { ResolverReturnType, DescribeRouteOptions } from "../../types";
+
+export function defineCommonTestRouteSpec(
+  responseSchema: ResolverReturnType,
+): DescribeRouteOptions {
+  return {
+    tags: ["test"],
+    summary: "Test route",
+    description: "This is a test route",
+    parameters: [
+      {
+        name: "id",
+        in: "param",
+        description: "The ID of the item",
+        example: "4daec17a-9ed2-40d2-b577-22bb89b96071",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "category",
+        in: "query",
+        description: "The category of the item",
+        example: "one",
+        required: false,
+      },
+    ],
+    responses: {
+      200: {
+        description: "Success",
+        content: {
+          "application/json": {
+            schema: responseSchema,
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/__tests__/valibot.test.ts
+++ b/src/__tests__/valibot.test.ts
@@ -3,30 +3,20 @@ import * as v from "valibot";
 import { describe, expect, it } from "vitest";
 import { generateSpecs } from "../handler.js";
 import { describeRoute, resolver, validator } from "../middlewares.js";
+import { defineCommonTestRouteSpec } from "./utils/route.js";
 
 describe("valibot", () => {
   it("basic", async () => {
     const app = new Hono().get(
-      "/",
-      describeRoute({
-        tags: ["test"],
-        summary: "Test route",
-        description: "This is a test route",
-        responses: {
-          200: {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  v.object({
-                    message: v.string(),
-                  }),
-                ),
-              },
-            },
-          },
-        },
-      }),
+      "/:id",
+      describeRoute(
+        defineCommonTestRouteSpec(resolver(v.object({ message: v.string() }))),
+      ),
+      validator("param", v.object({ id: v.string() })),
+      validator(
+        "query",
+        v.object({ category: v.optional(v.picklist(["one", "two", "three"])) }),
+      ),
       validator("json", v.object({ message: v.string() })),
       async (c) => {
         return c.json({ message: "Hello, world!" });

--- a/src/__tests__/zodv3.test.ts
+++ b/src/__tests__/zodv3.test.ts
@@ -3,31 +3,29 @@ import { describe, expect, it } from "vitest";
 import z from "zod";
 import { generateSpecs } from "../handler.js";
 import { describeRoute, resolver, validator } from "../middlewares.js";
+import { defineCommonTestRouteSpec } from "./utils/route.js";
 
 describe("zod v3", () => {
   it("basic", async () => {
     const app = new Hono().get(
-      "/",
-      describeRoute({
-        tags: ["test"],
-        summary: "Test route",
-        description: "This is a test route",
-        responses: {
-          200: {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  z.object({
-                    message: z.string(),
-                  }),
-                ),
-              },
-            },
-          },
-        },
-      }),
+      "/:id",
+      describeRoute(
+        defineCommonTestRouteSpec(
+          resolver(
+            z.object({
+              message: z.string(),
+            }),
+          ),
+        ),
+      ),
+      validator("param", z.object({ id: z.string() })),
       validator("json", z.object({ message: z.string() })),
+      validator(
+        "query",
+        z.object({
+          category: z.enum(["one", "two", "three"]).optional(),
+        }),
+      ),
       async (c) => {
         return c.json({ message: "Hello, world!" });
       },

--- a/src/__tests__/zodv4.test.ts
+++ b/src/__tests__/zodv4.test.ts
@@ -3,31 +3,29 @@ import { describe, expect, it } from "vitest";
 import z from "zod/v4";
 import { generateSpecs } from "../handler.js";
 import { describeRoute, resolver, validator } from "../middlewares.js";
+import { defineCommonTestRouteSpec } from "./utils/route.js";
 
 describe("zod v4", () => {
   it("basic", async () => {
     const app = new Hono().get(
-      "/",
-      describeRoute({
-        tags: ["test"],
-        summary: "Test route",
-        description: "This is a test route",
-        responses: {
-          200: {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  z.object({
-                    message: z.string(),
-                  }),
-                ),
-              },
-            },
-          },
-        },
-      }),
+      "/:id",
+      describeRoute(
+        defineCommonTestRouteSpec(
+          resolver(
+            z.object({
+              message: z.string(),
+            }),
+          ),
+        ),
+      ),
+      validator("param", z.object({ id: z.string() })),
       validator("json", z.object({ message: z.string() })),
+      validator(
+        "query",
+        z.object({
+          category: z.enum(["one", "two", "three"]).optional(),
+        }),
+      ),
       async (c) => {
         return c.json({ message: "Hello, world!" });
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export type SanitizedGenerateSpecOptions = Pick<
 
 export type DescribeRouteOptions = Omit<
   OpenAPIV3_1.OperationObject,
-  "responses" | "parameters"
+  "responses"
 > & {
   /**
    * Pass `true` to hide route from OpenAPI/swagger document

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,7 +88,17 @@ function mergeParameters(...params: (Parameter[] | undefined)[]): Parameter[] {
   const _params = params.flatMap((x) => x ?? []);
 
   const merged = _params.reduce((acc, param) => {
-    acc.set(paramKey(param), param);
+    const key = paramKey(param);
+    const existing = acc.get(key);
+    if (!existing) {
+      acc.set(paramKey(param), param);
+    } else {
+      // shallow merge
+      acc.set(key, {
+        ...existing,
+        ...param,
+      });
+    }
     return acc;
   }, new Map<string, Parameter>());
 


### PR DESCRIPTION
A copy of #127 but now targetting the `next` branch.
