### PR TITLE
feat: add automatic RC publishing for PRs

### DIFF
--- a/.github/workflows/pr-rc-publish.yml
+++ b/.github/workflows/pr-rc-publish.yml
@@ -1,0 +1,152 @@
+name: Publish PR RC Version
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, next]
+
+jobs:
+  publish-rc:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository # Only run for PRs from the same repo
+
+    permissions:
+      contents: read
+      pull-requests: write # Allow commenting on PRs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so we can access commit SHA
+          fetch-depth: 0
+
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run build
+        run: pnpm build
+
+      - name: Generate RC version
+        id: version
+        run: |
+          # Get current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          BASE_VERSION=$(echo $CURRENT_VERSION | cut -d'-' -f1)
+
+          # Generate unique RC version: base-rc-pr{PR_NUMBER}.{SHORT_SHA}
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          RC_VERSION="${BASE_VERSION}-rc-pr${{ github.event.number }}.${SHORT_SHA}"
+
+          echo "rc_version=${RC_VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated RC version: ${RC_VERSION}"
+
+      - name: Update package.json version
+        run: |
+          # Temporarily update version in package.json
+          npm version ${{ steps.version.outputs.rc_version }} --no-git-tag-version
+
+      - name: Publish to npm
+        run: |
+          # Publish with RC tag so it doesn't affect the main release
+          npm publish --tag rc --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ steps.version.outputs.rc_version }}';
+            const prNumber = context.issue.number;
+
+            // Check if we already commented on this PR
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.data.find(
+              comment => comment.user.type === 'Bot' &&
+              comment.body.includes('🚀 RC Version Published')
+            );
+
+            const body = `## 🚀 RC Version Published
+
+            This PR has been published as an RC version for testing:
+
+            **Version:** \`${version}\`
+
+            ### Install and test:
+            \`\`\`bash
+            pnpm add hono-openapi@${version}
+            # or
+            npm install hono-openapi@${version}
+            \`\`\`
+
+                         ### Alternative install with RC tag:
+             \`\`\`bash
+             pnpm add hono-openapi@rc
+             # or
+             npm install hono-openapi@rc
+             \`\`\`
+
+            > 📝 This RC version will be available until the PR is merged or closed.
+            `;
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }
+
+  cleanup-rc:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+
+    steps:
+      - name: Comment cleanup
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `## 🧹 PR Closed
+
+              This PR has been closed. The specific RC version \`${{ steps.version.outputs.rc_version || 'for this PR' }}\` is still available on npm, but the \`@rc\` tag now points to the latest RC version.
+
+              To use the stable release instead:
+              \`\`\`bash
+              pnpm add hono-openapi@latest
+              \`\`\`
+              `
+            });


### PR DESCRIPTION
## 🎯 Overview

Close #137

This PR adds automatic RC (Release Candidate) publishing for pull requests, enabling anyone to test PRs immediately without manual publishing by maintainers.

## 📦 What's Added

- GitHub workflow () that:
  - ✅ Runs tests and builds project on PR open/update
  - 🏷️ Generates unique RC versions: `{base-version}-rc-pr{PR#}.{short-commit}`
  - 📦 Publishes to npm with `@rc` tag
  - 💬 Comments on PRs with installation instructions
  - 🔒 Security: Only runs for same-repo PRs

## 🚀 User Experience

After merge, PR testers will see auto-generated comments like:

```markdown
## 🚀 RC Version Published

**Version:** `0.5.0-rc-pr123.a1b2c3d`

### Install and test:
```bash
pnpm add hono-openapi@0.5.0-rc-pr123.a1b2c3d
# or latest RC
pnpm add hono-openapi@rc
```
```

## 🔧 Required Setup for Maintainers (One-time)

### 1. Create NPM Token
```bash
npm login
npm token create --type=automation --read-write
```

### 2. Add GitHub Secret
1. Go to **Settings** → **Secrets and variables** → **Actions**
2. Click **"New repository secret"**
3. Name: `NPM_TOKEN`
4. Value: The automation token from step 1

## 🛡️ Security Features

- **Same-repo only**: Prevents malicious fork PRs
- **Branch restrictions**: Only `main`/`next` targets
- **Scoped permissions**: Automation token with limited access
- **No Git writes**: Temporary package.json changes only

## 🔍 Technical Details

### Workflow Triggers:
- `pull_request` events: `opened`, `synchronize`, `reopened`
- Target branches: `main`, `next`
- Repository: `rhinobase/hono-openapi` only

### Version Strategy:
- **Stable**: `@latest` (unchanged)
- **RC**: `@rc` (latest RC, overwritten)
- **Specific**: `@0.5.0-rc-pr123.a1b2c3d` (permanent)

### Build Process:
1. Run `pnpm test` (fails = no publish)
2. Run `pnpm build`
3. Generate unique version with PR# + commit SHA
4. Publish with `@rc` tag
5. Comment on PR with install instructions

## 📊 Benefits

- **⚡ Faster feedback**: Test PRs instantly
- **🤝 Community QA**: Anyone can test before merge  
- **⏰ Time savings**: No manual RC publishing
- **🔒 Safe versioning**: No interference with releases
- **🧹 Auto cleanup**: Clear communication on PR close

## 🐛 Troubleshooting

**"NPM_TOKEN not found"**: Add secret with exact name `NPM_TOKEN`
**"Permission denied"**: Ensure token has `--read-write` permissions
**"Tests failing"**: RC won't publish (by design) - fix tests first

Debug commands:
```bash
npm whoami --token YOUR_TOKEN
npm owner ls hono-openapi
pnpm install && pnpm test && pnpm build
```

## 🚦 Next Steps After Merge

1. ✅ Add `NPM_TOKEN` secret (required)
2. 🧪 Test workflow on a small PR
3. 📢 Update CONTRIBUTING.md to mention RC testing
4. 🎉 Enjoy automated PR testing!

---

**Ready to merge?** Just add the `NPM_TOKEN` secret and this will work on the next PR! 🚀