### PR TITLE
fix: removed "parameters" from DescribeRouteOptions type definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ type OperationId = string | ((route: RouterRoute) => string);
 
 export type DescribeRouteOptions = Omit<
   OpenAPIV3_1.OperationObject,
-  "responses" | "parameters" | "operationId"
+  "responses" | "operationId"
 > & {
   operationId?: OperationId;
   /**


### PR DESCRIPTION
Closes #153, Closes #77