### PR TITLE
fix: correctly pass options to `toOpenAPISchema` in resolver

### DIFF
--- a/src/__tests__/__snapshots__/zodv4.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv4.test.ts.snap
@@ -130,6 +130,69 @@ exports[`zod v4 > with metadata 1`] = `
 }
 `;
 
+exports[`zod v4 > with options 1`] = `
+{
+  "components": {},
+  "info": {
+    "description": "Development documentation",
+    "title": "Hono Documentation",
+    "version": "0.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "This is a test route",
+        "operationId": "getIndex",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "message",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "date": {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "date",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Success",
+          },
+        },
+        "summary": "Test route",
+        "tags": [
+          "test",
+        ],
+      },
+    },
+  },
+  "tags": undefined,
+}
+`;
+
 exports[`zod v4 > with response description 1`] = `
 {
   "components": {

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -5,6 +5,7 @@ import {
 } from "@standard-community/standard-json";
 import {
   loadVendor as loadVendorOpenAPI,
+  type ToOpenAPISchemaContext,
   toOpenAPISchema,
 } from "@standard-community/standard-openapi";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
@@ -51,13 +52,14 @@ export function loadVendor(
 export function resolver<Schema extends StandardSchemaV1>(
   schema: Schema,
   options?: Record<string, unknown>,
+  openAPIOptions?: Partial<ToOpenAPISchemaContext>,
 ) {
   return {
     vendor: schema["~standard"].vendor,
     validate: schema["~standard"].validate,
     toJSONSchema: () =>
       toJsonSchema(schema, options) as JSONSchema7 | Promise<JSONSchema7>,
-    toOpenAPISchema: () => toOpenAPISchema(schema, options),
+    toOpenAPISchema: () => toOpenAPISchema(schema, openAPIOptions ?? options),
   };
 }
 


### PR DESCRIPTION
The `resolver` function takes in a `options` parameter, and passed it to both `toJsonSchema` and `toOpenAPISchema`. However these two functions actually expects two different shapes of the `options`. For `toJsonSchema`, the options is directly passed to the underlaying schema lib. But for `toOpenAPISchema`,  it takes in { component, options }, and the latter sub-`options` is passed to the actual schema libs.

The test i added is a good example of the use case that requires user to pass options to underlaying lib (in this example, zod), and shows how the new interface should be used.

The current API design is far from perfect, but this is the best solution I can think of to avoid breaking changes.