### PR TITLE
Fix duplicate parameters in OpenAPI spec (#194)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,6 +126,8 @@ function mergeSpecs(
 
             if (key === "tags") {
               prev[key] = Array.from(new Set(values));
+            } else if (key === "parameters") {
+              prev[key] = mergeParameters(prev[key], ...value);
             } else {
               prev[key] = values;
             }


### PR DESCRIPTION
- Fix duplicate parameters in OpenAPI specification generation by merging parameters arrays

Closes #194.