### PR TITLE
Update to @hono/standard-validator 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     }
   },
   "peerDependencies": {
-    "@hono/standard-validator": "^0.1.2",
+    "@hono/standard-validator": "^0.2.0",
     "@standard-community/standard-json": "^0.3.5",
-    "@standard-community/standard-openapi": "^0.2.8",
+    "@standard-community/standard-openapi": "^0.2.9",
     "@types/json-schema": "^7.0.15",
     "hono": "^4.8.3",
     "openapi-types": "^12.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@hono/standard-validator':
-        specifier: ^0.1.2
-        version: 0.1.2(@standard-schema/spec@1.0.0)(hono@4.8.3)
+        specifier: ^0.2.0
+        version: 0.2.0(@standard-schema/spec@1.0.0)(hono@4.8.3)
       '@standard-community/standard-json':
         specifier: ^0.3.5
         version: 0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76)
       '@standard-community/standard-openapi':
-        specifier: ^0.2.8
-        version: 0.2.8(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76))(@standard-schema/spec@1.0.0)(arktype@2.1.22)(effect@3.17.13)(openapi-types@12.1.3)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.2.9
+        version: 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76))(@standard-schema/spec@1.0.0)(arktype@2.1.22)(effect@3.17.13)(openapi-types@12.1.3)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -306,8 +306,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@hono/standard-validator@0.1.2':
-    resolution: {integrity: sha512-mVyv2fpx/o0MNAEhjXhvuVbW3BWTGnf8F4w8ZifztE+TWXjUAKr7KAOZfcDhVrurgVhKw7RbTnEog2beZM6QtQ==}
+  '@hono/standard-validator@0.2.0':
+    resolution: {integrity: sha512-pFq0UVAnjzXcDAgqFpDeVL3MOUPrlIh/kPqBDvbCYoThVhhS+Vf37VcdsakdOFFGiqoiYVxp3LifXFhGhp/rgQ==}
     peerDependencies:
       '@standard-schema/spec': 1.0.0
       hono: '>=3.9.0'
@@ -582,8 +582,8 @@ packages:
       zod-to-json-schema:
         optional: true
 
-  '@standard-community/standard-openapi@0.2.8':
-    resolution: {integrity: sha512-80ap74p5oy/SU4al5HkPwO5+NbN2wH/FBr6kwaE5ROq7AvcDFaxzUfTazewroNaCotbvdGcvzXb9oEoOIyfC/Q==}
+  '@standard-community/standard-openapi@0.2.9':
+    resolution: {integrity: sha512-htj+yldvN1XncyZi4rehbf9kLbu8os2Ke/rfqoZHCMHuw34kiF3LP/yQPdA0tQ940y8nDq3Iou8R3wG+AGGyvg==}
     peerDependencies:
       '@standard-community/standard-json': ^0.3.5
       '@standard-schema/spec': ^1.0.0
@@ -1329,7 +1329,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@hono/standard-validator@0.1.2(@standard-schema/spec@1.0.0)(hono@4.8.3)':
+  '@hono/standard-validator@0.2.0(@standard-schema/spec@1.0.0)(hono@4.8.3)':
     dependencies:
       '@standard-schema/spec': 1.0.0
       hono: 4.8.3
@@ -1559,7 +1559,7 @@ snapshots:
       valibot: 1.1.0(typescript@5.8.3)
       zod: 3.25.76
 
-  '@standard-community/standard-openapi@0.2.8(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76))(@standard-schema/spec@1.0.0)(arktype@2.1.22)(effect@3.17.13)(openapi-types@12.1.3)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)':
+  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76))(@standard-schema/spec@1.0.0)(arktype@2.1.22)(effect@3.17.13)(openapi-types@12.1.3)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76)
       '@standard-schema/spec': 1.0.0


### PR DESCRIPTION
`@hono/standard-validator 0.2.0` was recently released with minor improvements. See changelog here: https://github.com/honojs/middleware/releases/tag/%40hono%2Fstandard-validator%400.2.0

I've also updated the patch version for `@standard-community/standard-openapi`