### PR TITLE
generateOperationId should transform path to an OpenApi path

### DIFF
--- a/src/__tests__/__snapshots__/zodv3.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv3.test.ts.snap
@@ -86,7 +86,7 @@ exports[`zod v3 > describeResponse 1`] = `
     "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "get:id",
+        "operationId": "getById",
         "parameters": [
           {
             "$ref": "#/components/parameters/Param",
@@ -238,7 +238,7 @@ exports[`zod v3 > with reference in parameter 1`] = `
     "/{id}": {
       "get": {
         "description": "This is a test route",
-        "operationId": "get:id",
+        "operationId": "getById",
         "parameters": [
           {
             "$ref": "#/components/parameters/Param",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,33 +20,32 @@ export const ALLOWED_METHODS = [
 
 export type AllowedMethods = (typeof ALLOWED_METHODS)[number];
 
+const toOpenAPIPathSegment = (segment: string) => {
+  let tmp = segment;
+
+  // Example - ":id"
+  if (tmp.startsWith(":")) {
+    const match = tmp.match(/^:([^{?]+)(?:{(.+)})?(\?)?$/);
+    if (match) {
+      const paramName = match[1];
+      tmp = `{${paramName}}`;
+    } else {
+      // Remove the leading colon ":"
+      tmp = tmp.slice(1, tmp.length);
+
+      // If it ends with "?", remove it
+      // This is for optional parameters
+      if (tmp.endsWith("?")) tmp = tmp.slice(0, -1);
+
+      tmp = `{${tmp}}`;
+    }
+  }
+
+  return tmp;
+};
+
 const toOpenAPIPath = (path: string) =>
-  path
-    .split("/")
-    .map((x) => {
-      let tmp = x;
-
-      // Example - ":id"
-      if (tmp.startsWith(":")) {
-        const match = tmp.match(/^:([^{?]+)(?:{(.+)})?(\?)?$/);
-        if (match) {
-          const paramName = match[1];
-          tmp = `{${paramName}}`;
-        } else {
-          // Remove the leading colon ":"
-          tmp = tmp.slice(1, tmp.length);
-
-          // If it ends with "?", remove it
-          // This is for optional parameters
-          if (tmp.endsWith("?")) tmp = tmp.slice(0, -1);
-
-          tmp = `{${tmp}}`;
-        }
-      }
-
-      return tmp;
-    })
-    .join("/");
+  path.split("/").map(toOpenAPIPathSegment).join("/");
 
 const capitalize = (word: string) =>
   word.charAt(0).toUpperCase() + word.slice(1);
@@ -57,10 +56,11 @@ const generateOperationId = (route: RouterRoute) => {
   if (route.path === "/") return `${operationId}Index`;
 
   for (const segment of route.path.split("/")) {
-    if (segment.charCodeAt(0) === 123) {
-      operationId += `By${capitalize(segment.slice(1, -1))}`;
+    const openApiPathSegment = toOpenAPIPathSegment(segment);
+    if (openApiPathSegment.charCodeAt(0) === 123) {
+      operationId += `By${capitalize(openApiPathSegment.slice(1, -1))}`;
     } else {
-      operationId += capitalize(segment);
+      operationId += capitalize(openApiPathSegment);
     }
   }
 


### PR DESCRIPTION
Currently `generateOperationId` gets passed the hono path but handles it as it would be a an OpenApi path without actually transforming it. Therefore, the operationId can contain colons for paths with path parameters as the implemented handling for path parameters never gets called.

This PR adds the transformation of the hono path to an OpenApi path before the special handling for path parameters is done and the path is transformed to an operationId.

This change also solves other edge cases like optional path parameters and RegExp as those are already handled by `toOpenAPIPath` (rather the extracted `toOpenAPIPathSegment`)