### PR TITLE
fix: path context matching should use prefix comparison instead of regex

### DIFF
--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -88,6 +88,85 @@ describe("path parameters", () => {
   });
 });
 
+describe("path context matching", () => {
+  it("should not apply describeRoute context from one router to unrelated routes with same trailing path", async () => {
+    // Reproduces https://github.com/rhinobase/hono-openapi/issues/143
+    // /players middleware should NOT apply to /collections/players
+    const app = new Hono();
+
+    app.route(
+      "/players",
+      new Hono().use(
+        describeRoute({
+          tags: ["Players"],
+        }),
+      ),
+    );
+
+    app.route(
+      "/collections",
+      new Hono()
+        .use(
+          describeRoute({
+            tags: ["Player Collections"],
+          }),
+        )
+        .get(
+          "/players",
+          describeRoute({
+            summary: "Hello",
+          }),
+          async (c) => {
+            return c.body("hello world");
+          },
+        ),
+    );
+
+    const specs = await generateSpecs(app);
+
+    const collectionPlayers = specs.paths["/collections/players"]?.get;
+    expect(collectionPlayers).toBeDefined();
+    // Should only have "Player Collections" tag, NOT "Players"
+    expect(collectionPlayers?.tags).toEqual(["Player Collections"]);
+    expect(collectionPlayers?.tags).not.toContain("Players");
+  });
+
+  it("should correctly scope context to prefix-matched paths only", async () => {
+    // Module-level middleware with describeRoute on /module should not
+    // apply to /module2 even though /module2 starts with /module
+    const app = new Hono();
+
+    app.route(
+      "/module",
+      new Hono().use(
+        describeRoute({
+          tags: ["Module"],
+        }),
+      ),
+    );
+
+    app.route(
+      "/module2",
+      new Hono().get(
+        "/endpoint",
+        describeRoute({
+          summary: "Module2 endpoint",
+        }),
+        async (c) => {
+          return c.body("hello");
+        },
+      ),
+    );
+
+    const specs = await generateSpecs(app);
+
+    const module2Endpoint = specs.paths["/module2/endpoint"]?.get;
+    expect(module2Endpoint).toBeDefined();
+    // /module2/endpoint should NOT get the "Module" tag from /module middleware
+    expect(module2Endpoint?.tags).toBeUndefined();
+  });
+});
+
 describe("basic", () => {
   it("operationId", async () => {
     const operationId = vi.fn(() => "hello");

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -165,6 +165,68 @@ describe("path context matching", () => {
     // /module2/endpoint should NOT get the "Module" tag from /module middleware
     expect(module2Endpoint?.tags).toBeUndefined();
   });
+
+  it("should not leak context across sibling routers mounted with use('/') and a basePath", async () => {
+    // Reproduces the exact MRE from
+    // https://github.com/rhinobase/hono-openapi/issues/143
+    // where the context key has no trailing wildcard (from `use("/")`).
+    const module = new Hono();
+    module.use("/", describeRoute({ tags: ["Module"] }));
+    module.get("/1", describeRoute({ summary: "1" }), (c) => c.json({}));
+
+    const module2 = new Hono();
+    module2.use("/", describeRoute({ tags: ["Module2"] }));
+    module2.get("/2", describeRoute({ summary: "2" }), (c) => c.json({}));
+
+    const api = new Hono().basePath("/api");
+    api.route("/module", module);
+    api.route("/module2", module2);
+
+    const specs = await generateSpecs(api);
+
+    // /api/module/1 should only carry the "Module" tag
+    const moduleOne = specs.paths["/api/module/1"]?.get;
+    expect(moduleOne?.tags).toEqual(["Module"]);
+    expect(moduleOne?.tags).not.toContain("Module2");
+
+    // /api/module2/2 should only carry the "Module2" tag
+    const moduleTwo = specs.paths["/api/module2/2"]?.get;
+    expect(moduleTwo?.tags).toEqual(["Module2"]);
+    expect(moduleTwo?.tags).not.toContain("Module");
+  });
+
+  it("should apply root-level use() context to every route", async () => {
+    // A context registered at the app root (key "/*", i.e. empty prefix)
+    // must apply to all paths.
+    const app = new Hono()
+      .use(describeRoute({ tags: ["Global"] }))
+      .get("/foo", describeRoute({ summary: "foo" }), (c) => c.body("x"))
+      .get("/bar/baz", describeRoute({ summary: "bar" }), (c) => c.body("x"));
+
+    const specs = await generateSpecs(app);
+
+    expect(specs.paths["/foo"]?.get?.tags).toEqual(["Global"]);
+    expect(specs.paths["/bar/baz"]?.get?.tags).toEqual(["Global"]);
+  });
+
+  it("should apply context to nested sub-paths of the mounted prefix", async () => {
+    // Positive case: context on /players must still reach /players and
+    // deeper paths like /players/{id}.
+    const app = new Hono();
+
+    app.route(
+      "/players",
+      new Hono()
+        .use(describeRoute({ tags: ["Players"] }))
+        .get("/", describeRoute({ summary: "list" }), (c) => c.body("x"))
+        .get("/:id", describeRoute({ summary: "detail" }), (c) => c.body("x")),
+    );
+
+    const specs = await generateSpecs(app);
+
+    expect(specs.paths["/players"]?.get?.tags).toEqual(["Players"]);
+    expect(specs.paths["/players/{id}"]?.get?.tags).toEqual(["Players"]);
+  });
 });
 
 describe("basic", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,8 +96,15 @@ function getPathContext(path: string) {
   const context: RegisterSchemaPathOptions["specs"][] = [];
 
   for (const [key, data] of specsByPathContext) {
-    // TODO: Improve path matching https://github.com/rhinobase/hono-openapi/issues/143
-    if (data && path.match(key)) {
+    if (!data) continue;
+
+    // Strip trailing wildcard (e.g., "/players/*" -> "/players")
+    const prefix = key.endsWith("/*") ? key.slice(0, -2) : key;
+
+    // Context should only apply when the path starts with the prefix,
+    // and either matches exactly or continues with a "/" segment boundary.
+    // This prevents "/players" context from matching "/collections/players".
+    if (path === prefix || path.startsWith(`${prefix}/`)) {
       context.push(data);
     }
   }


### PR DESCRIPTION
## Summary

- Fixes `getPathContext()` in `utils.ts` to use proper path prefix matching instead of `String.match()` (regex substring matching)
- `describeRoute` middleware context on one router no longer bleeds into unrelated routes on different routers that happen to share a trailing path segment

Fixes #143
Fixes #119

## Problem

`getPathContext()` used `path.match(key)` which treats `key` as a regex pattern. This caused `/players` context to match inside `/collections/players` because `/players` is a substring match. Similarly, `/module` would match `/module2/endpoint`.

## Fix

Replaced regex matching with explicit prefix comparison:
1. Strip trailing wildcard from the context key (e.g., `/players/*` → `/players`)
2. Check if the target path equals the prefix exactly, or starts with `prefix/` (segment boundary)

This ensures `/players` context only applies to `/players` and `/players/...`, not `/collections/players`.