### PR TITLE
feat: auto-include 400 validation error response when validator() is used

### DIFF
--- a/src/__tests__/__snapshots__/arktype.test.ts.snap
+++ b/src/__tests__/__snapshots__/arktype.test.ts.snap
@@ -51,6 +51,33 @@ exports[`arktype > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -97,6 +124,33 @@ exports[`arktype > morph schema in json body without explicit fallback 1`] = `
         },
         "responses": {
           "200": {},
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
       },
     },
@@ -131,6 +185,33 @@ exports[`arktype > morph schema in param without explicit fallback 1`] = `
         ],
         "responses": {
           "200": {},
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
       },
     },
@@ -196,6 +277,33 @@ exports[`arktype > with metadata 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -242,6 +350,33 @@ exports[`arktype > with options 1`] = `
         },
         "responses": {
           "200": {},
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
       },
     },

--- a/src/__tests__/__snapshots__/arktype.test.ts.snap
+++ b/src/__tests__/__snapshots__/arktype.test.ts.snap
@@ -71,6 +71,7 @@ exports[`arktype > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -144,6 +145,7 @@ exports[`arktype > morph schema in json body without explicit fallback 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -205,6 +207,7 @@ exports[`arktype > morph schema in param without explicit fallback 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -297,6 +300,7 @@ exports[`arktype > with metadata 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -370,6 +374,7 @@ exports[`arktype > with options 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/__snapshots__/effect.test.ts.snap
+++ b/src/__tests__/__snapshots__/effect.test.ts.snap
@@ -53,6 +53,33 @@ exports[`effect > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -114,6 +141,33 @@ exports[`effect > with reference in parameter 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",

--- a/src/__tests__/__snapshots__/effect.test.ts.snap
+++ b/src/__tests__/__snapshots__/effect.test.ts.snap
@@ -73,6 +73,7 @@ exports[`effect > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -162,6 +163,7 @@ exports[`effect > with reference in parameter 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/__snapshots__/sury.test.ts.snap
+++ b/src/__tests__/__snapshots__/sury.test.ts.snap
@@ -53,6 +53,33 @@ exports[`sury > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -134,6 +161,33 @@ exports[`sury > with metadata 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",

--- a/src/__tests__/__snapshots__/sury.test.ts.snap
+++ b/src/__tests__/__snapshots__/sury.test.ts.snap
@@ -73,6 +73,7 @@ exports[`sury > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -182,6 +183,7 @@ exports[`sury > with metadata 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/__snapshots__/typebox.test.ts.snap
+++ b/src/__tests__/__snapshots__/typebox.test.ts.snap
@@ -51,6 +51,33 @@ exports[`typebox > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -122,6 +149,33 @@ exports[`typebox > with JSON Schema 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -190,6 +244,33 @@ exports[`typebox > with metadata 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",

--- a/src/__tests__/__snapshots__/typebox.test.ts.snap
+++ b/src/__tests__/__snapshots__/typebox.test.ts.snap
@@ -71,6 +71,7 @@ exports[`typebox > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -169,6 +170,7 @@ exports[`typebox > with JSON Schema 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -265,6 +267,7 @@ exports[`typebox > with metadata 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/__snapshots__/valibot.test.ts.snap
+++ b/src/__tests__/__snapshots__/valibot.test.ts.snap
@@ -51,6 +51,33 @@ exports[`valibot > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -120,6 +147,33 @@ exports[`valibot > with metadata 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -169,6 +223,33 @@ exports[`valibot > with transformation 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",

--- a/src/__tests__/__snapshots__/valibot.test.ts.snap
+++ b/src/__tests__/__snapshots__/valibot.test.ts.snap
@@ -71,6 +71,7 @@ exports[`valibot > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -167,6 +168,7 @@ exports[`valibot > with metadata 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -244,6 +246,7 @@ exports[`valibot > with transformation 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/__snapshots__/zodv3.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv3.test.ts.snap
@@ -51,6 +51,33 @@ exports[`zod v3 > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -134,6 +161,33 @@ exports[`zod v3 > describeResponse 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",
@@ -219,6 +273,33 @@ exports[`zod v3 > operation id for path with dash 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -287,6 +368,33 @@ exports[`zod v3 > with metadata 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",
@@ -371,6 +479,33 @@ exports[`zod v3 > with reference in parameter 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",

--- a/src/__tests__/__snapshots__/zodv3.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv3.test.ts.snap
@@ -71,6 +71,7 @@ exports[`zod v3 > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -182,6 +183,7 @@ exports[`zod v3 > describeResponse 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -293,6 +295,7 @@ exports[`zod v3 > operation id for path with dash 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -389,6 +392,7 @@ exports[`zod v3 > with metadata 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -500,6 +504,7 @@ exports[`zod v3 > with reference in parameter 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/__snapshots__/zodv4.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv4.test.ts.snap
@@ -51,6 +51,33 @@ exports[`zod v4 > basic 1`] = `
             },
             "description": "Success",
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
         },
         "summary": "Test route",
         "tags": [
@@ -95,7 +122,35 @@ exports[`zod v4 > with global validator 1`] = `
             },
           },
         ],
-        "responses": {},
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
+          },
+        },
         "summary": "Test route",
         "tags": [
           "test",
@@ -163,6 +218,33 @@ exports[`zod v4 > with metadata 1`] = `
               },
             },
             "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {},
+                    "error": {
+                      "items": {},
+                      "type": "array",
+                    },
+                    "success": {
+                      "enum": [
+                        false,
+                      ],
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Validation Error",
           },
         },
         "summary": "Test route",

--- a/src/__tests__/__snapshots__/zodv4.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv4.test.ts.snap
@@ -71,6 +71,7 @@ exports[`zod v4 > basic 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -143,6 +144,7 @@ exports[`zod v4 > with global validator 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },
@@ -239,6 +241,7 @@ exports[`zod v4 > with metadata 1`] = `
                   "required": [
                     "success",
                     "error",
+                    "data",
                   ],
                   "type": "object",
                 },

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -220,3 +220,148 @@ describe("basic", () => {
     expect(specs).toMatchSnapshot();
   });
 });
+
+describe("default validation error response", () => {
+  it("should include a 400 response when validator is used", async () => {
+    const app = new Hono().post(
+      "/",
+      validator("json", z.object({ message: z.string() })),
+      async (c) => {
+        return c.json({ message: "Hello, world!" });
+      },
+    );
+
+    const specs = await generateSpecs(app);
+
+    const postSpec = specs.paths["/"]?.post;
+    expect(postSpec?.responses?.["400"]).toBeDefined();
+    expect(postSpec?.responses?.["400"]).toMatchObject({
+      description: "Validation Error",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              success: { type: "boolean", enum: [false] },
+              error: { type: "array", items: {} },
+              data: {},
+            },
+            required: ["success", "error"],
+          },
+        },
+      },
+    });
+  });
+
+  it("should not include 400 when defaultValidationErrorResponse is false", async () => {
+    const app = new Hono().post(
+      "/",
+      validator("json", z.object({ message: z.string() })),
+      async (c) => {
+        return c.json({ message: "Hello, world!" });
+      },
+    );
+
+    const specs = await generateSpecs(app, {
+      defaultValidationErrorResponse: false,
+    });
+
+    const postSpec = specs.paths["/"]?.post;
+    expect(postSpec?.responses?.["400"]).toBeUndefined();
+  });
+
+  it("should allow a custom 400 response via defaultValidationErrorResponse", async () => {
+    const app = new Hono().post(
+      "/",
+      validator("json", z.object({ message: z.string() })),
+      async (c) => {
+        return c.json({ message: "Hello, world!" });
+      },
+    );
+
+    const customResponse = {
+      description: "Custom Validation Error",
+      content: {
+        "application/json": {
+          schema: {
+            type: "object" as const,
+            properties: {
+              message: { type: "string" as const },
+            },
+          },
+        },
+      },
+    };
+
+    const specs = await generateSpecs(app, {
+      defaultValidationErrorResponse: customResponse,
+    });
+
+    const postSpec = specs.paths["/"]?.post;
+    expect(postSpec?.responses?.["400"]).toEqual(customResponse);
+  });
+
+  it("should not override user-defined 400 response in describeRoute", async () => {
+    const app = new Hono().post(
+      "/",
+      describeRoute({
+        responses: {
+          200: { description: "OK" },
+          400: { description: "My custom 400" },
+        },
+      }),
+      validator("json", z.object({ message: z.string() })),
+      async (c) => {
+        return c.json({ message: "Hello, world!" });
+      },
+    );
+
+    const specs = await generateSpecs(app);
+
+    const postSpec = specs.paths["/"]?.post;
+    // The user-defined 400 should take precedence
+    expect(postSpec?.responses?.["400"]).toMatchObject({
+      description: "My custom 400",
+    });
+  });
+
+  it("should not include 400 for routes without validators", async () => {
+    const app = new Hono().get(
+      "/",
+      describeRoute({
+        responses: {
+          200: { description: "OK" },
+        },
+      }),
+      async (c) => {
+        return c.json({ ok: true });
+      },
+    );
+
+    const specs = await generateSpecs(app);
+
+    const getSpec = specs.paths["/"]?.get;
+    expect(getSpec?.responses?.["400"]).toBeUndefined();
+  });
+
+  it("should not include 400 for routes with only path params and no validator", async () => {
+    const app = new Hono().get(
+      "/users/:id",
+      describeRoute({
+        responses: {
+          200: { description: "OK" },
+        },
+      }),
+      async (c) => {
+        return c.json({ id: c.req.param("id") });
+      },
+    );
+
+    const specs = await generateSpecs(app);
+
+    const getSpec = specs.paths["/users/{id}"]?.get;
+    expect(getSpec).toBeDefined();
+    // Auto-generated path params should NOT trigger 400
+    expect(getSpec?.responses?.["400"]).toBeUndefined();
+  });
+});

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -246,7 +246,7 @@ describe("default validation error response", () => {
               error: { type: "array", items: {} },
               data: {},
             },
-            required: ["success", "error"],
+            required: ["success", "error", "data"],
           },
         },
       },
@@ -424,5 +424,71 @@ describe("default validation error response", () => {
     expect(op?.responses?.["400"]).toBeDefined();
     // The marker must be stripped before emitting the spec.
     expect(JSON.stringify(op)).not.toContain("HonoOpenAPIValidator");
+  });
+
+  it("should inject a single 400 when multiple validators are on one route", async () => {
+    const app = new Hono().post(
+      "/",
+      validator("json", z.object({ a: z.string() })),
+      validator("query", z.object({ b: z.string() })),
+      async (c) => c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+
+    const responses = specs.paths["/"]?.post?.responses ?? {};
+    expect(responses["400"]).toBeDefined();
+    expect(Object.keys(responses).filter((k) => k === "400")).toHaveLength(1);
+  });
+
+  it("should give each validator route its own 400 object (no shared reference)", async () => {
+    const app = new Hono()
+      .post("/a", validator("json", z.object({ a: z.string() })), (c) =>
+        c.json({ ok: true }),
+      )
+      .post("/b", validator("json", z.object({ b: z.string() })), (c) =>
+        c.json({ ok: true }),
+      );
+
+    const specs = await generateSpecs(app);
+
+    const a = specs.paths["/a"]?.post?.responses?.["400"];
+    const b = specs.paths["/b"]?.post?.responses?.["400"];
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    // Distinct object identities — mutating one must not affect the other.
+    expect(a).not.toBe(b);
+  });
+
+  it("should accept a $ref object as the custom validation error response", async () => {
+    const app = new Hono().post(
+      "/",
+      validator("json", z.object({ a: z.string() })),
+      (c) => c.json({ ok: true }),
+    );
+
+    const ref = { $ref: "#/components/responses/ValidationError" };
+    const specs = await generateSpecs(app, {
+      // @ts-expect-error a ReferenceObject is a valid ResponseObject slot
+      defaultValidationErrorResponse: ref,
+    });
+
+    expect(specs.paths["/"]?.post?.responses?.["400"]).toEqual(ref);
+  });
+
+  it("should mark data as required in the default validation error schema", async () => {
+    // @hono/standard-validator always returns { success, error, data } on a
+    // validation error, so all three are required.
+    const app = new Hono().post(
+      "/",
+      validator("json", z.object({ a: z.string() })),
+      (c) => c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+
+    const schema = (specs.paths["/"]?.post?.responses?.["400"] as any)
+      ?.content?.["application/json"]?.schema;
+    expect(schema?.required).toEqual(["success", "error", "data"]);
   });
 });

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -364,4 +364,65 @@ describe("default validation error response", () => {
     // Auto-generated path params should NOT trigger 400
     expect(getSpec?.responses?.["400"]).toBeUndefined();
   });
+
+  it("should not include 400 for manually documented parameters without a validator", async () => {
+    const app = new Hono().get(
+      "/search",
+      describeRoute({
+        parameters: [{ in: "query", name: "q", schema: { type: "string" } }],
+        responses: { 200: { description: "OK" } },
+      }),
+      async (c) => c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+
+    // Documenting a query parameter is not the same as validating it.
+    expect(specs.paths["/search"]?.get?.responses?.["400"]).toBeUndefined();
+  });
+
+  it("should not include 400 for a manually documented requestBody without a validator", async () => {
+    const app = new Hono().post(
+      "/upload",
+      describeRoute({
+        requestBody: {
+          content: { "application/json": { schema: { type: "object" } } },
+        },
+        responses: { 200: { description: "OK" } },
+      }),
+      async (c) => c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+
+    expect(specs.paths["/upload"]?.post?.responses?.["400"]).toBeUndefined();
+  });
+
+  it("should include 400 for a param validator", async () => {
+    const app = new Hono().get(
+      "/users/:id",
+      validator("param", z.object({ id: z.string() })),
+      async (c) => c.json({ id: c.req.param("id") }),
+    );
+
+    const specs = await generateSpecs(app);
+
+    expect(specs.paths["/users/{id}"]?.get?.responses?.["400"]).toBeDefined();
+  });
+
+  it("should not leak the internal validation marker into the emitted spec", async () => {
+    const app = new Hono().post(
+      "/",
+      describeRoute({ responses: { 200: { description: "OK" } } }),
+      validator("json", z.object({ message: z.string() })),
+      async (c) => c.json({ message: "Hello, world!" }),
+    );
+
+    const specs = await generateSpecs(app);
+
+    const op = specs.paths["/"]?.post;
+    expect(op?.responses?.["400"]).toBeDefined();
+    // The marker must be stripped before emitting the spec.
+    expect(JSON.stringify(op)).not.toContain("HonoOpenAPIValidator");
+  });
 });

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -31,6 +31,31 @@ const DEFAULT_OPTIONS: Partial<GenerateSpecOptions> = {
   exclude: [],
   excludeMethods: ["OPTIONS"],
   excludeTags: [],
+  defaultValidationErrorResponse: true,
+};
+
+/**
+ * Default 400 response matching `@hono/standard-validator`'s error output:
+ * `{ success: false, error: <issues>, data: <input> }`
+ */
+const DEFAULT_VALIDATION_ERROR: OpenAPIV3_1.ResponseObject = {
+  description: "Validation Error",
+  content: {
+    "application/json": {
+      schema: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", enum: [false] },
+          error: {
+            type: "array",
+            items: {},
+          },
+          data: {},
+        },
+        required: ["success", "error"],
+      },
+    },
+  },
 };
 
 /**
@@ -80,6 +105,7 @@ export async function generateSpecs<
       ...DEFAULT_OPTIONS,
       ...options,
     },
+    validationErrorResponse: DEFAULT_VALIDATION_ERROR,
   };
 
   const _documentation = ctx.options.documentation ?? {};

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -53,7 +53,7 @@ const DEFAULT_VALIDATION_ERROR: OpenAPIV3_1.ResponseObject = {
           },
           data: {},
         },
-        required: ["success", "error"],
+        required: ["success", "error", "data"],
       },
     },
   },

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -23,6 +23,7 @@ import {
   registerSchemaPath,
   removeExcludedPaths,
   uniqueSymbol,
+  VALIDATION_MARKER,
 } from "./utils";
 
 const DEFAULT_OPTIONS: Partial<GenerateSpecOptions> = {
@@ -269,8 +270,13 @@ async function getSpec(
   }
 
   const result = await middlewareHandler.toOpenAPISchema();
-  const docs: Pick<OpenAPIV3_1.OperationObject, "parameters" | "requestBody"> =
-    { ...defaultOptions };
+  const docs: Pick<OpenAPIV3_1.OperationObject, "parameters" | "requestBody"> &
+    Record<string, unknown> = {
+    ...defaultOptions,
+    // Mark this operation as validator-derived so a default 400 validation
+    // error response can be auto-injected later (see removeExcludedPaths).
+    [VALIDATION_MARKER]: true,
+  };
 
   if (
     middlewareHandler.target === "form" ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,15 @@ export type GenerateSpecOptions = {
    * Default options for `describeRoute` method
    */
   defaultOptions: Partial<Record<AllowedMethods | "ALL", DescribeRouteOptions>>;
+
+  /**
+   * Automatically include a 400 validation error response for routes
+   * that use `validator()`. Set to `false` to disable, `true` to use
+   * the built-in schema, or provide a custom `ResponseObject`.
+   *
+   * @default true
+   */
+  defaultValidationErrorResponse: boolean | OpenAPIV3_1.ResponseObject;
 };
 
 type OperationId = string | ((route: RouterRoute) => string);
@@ -157,4 +166,5 @@ type SanitizedGenerateSpecOptions = Pick<
 export type SpecContext = {
   components: OpenAPIV3_1.ComponentsObject;
   options: SanitizedGenerateSpecOptions;
+  validationErrorResponse?: OpenAPIV3_1.ResponseObject;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,7 +155,8 @@ type HaveDefaultValues =
   | "excludeStaticFile"
   | "exclude"
   | "excludeMethods"
-  | "excludeTags";
+  | "excludeTags"
+  | "defaultValidationErrorResponse";
 
 type SanitizedGenerateSpecOptions = Pick<
   GenerateSpecOptions,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,6 +245,12 @@ export function removeExcludedPaths(
 
       if (schema == null) continue;
 
+      // Check for validator usage BEFORE auto-generating path parameters,
+      // so we only detect params from actual validator() calls
+      const hasValidation =
+        schema.requestBody ||
+        (schema.parameters && schema.parameters.length > 0);
+
       if (key.includes("{")) {
         // Clone the parameters array to avoid mutating shared references
         schema.parameters = schema.parameters ? [...schema.parameters] : [];
@@ -299,6 +305,21 @@ export function removeExcludedPaths(
         schema.responses = {
           200: {},
         };
+      }
+
+      // Auto-inject a 400 validation error response for routes that use validators
+      if (
+        hasValidation &&
+        ctx.options.defaultValidationErrorResponse !== false &&
+        !schema.responses["400"]
+      ) {
+        const errorResponse = ctx.options.defaultValidationErrorResponse;
+
+        if (typeof errorResponse === "object") {
+          schema.responses["400"] = errorResponse;
+        } else if (ctx.validationErrorResponse) {
+          schema.responses["400"] = ctx.validationErrorResponse;
+        }
       }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,15 @@ import type { RegisterSchemaPathOptions, SpecContext } from "./types";
  */
 export const uniqueSymbol = Symbol("openapi");
 
+/**
+ * Internal marker key set on an operation's spec when it is produced by a
+ * `validator()` middleware. It is used to decide whether to auto-inject the
+ * default 400 validation error response, and is stripped from the operation
+ * before the spec is emitted. Must be an enumerable string key so it survives
+ * the `Object.entries`-based merge in `mergeSpecs`.
+ */
+export const VALIDATION_MARKER = "__HonoOpenAPIValidator__";
+
 export const ALLOWED_METHODS = [
   "GET",
   "PUT",
@@ -245,11 +254,12 @@ export function removeExcludedPaths(
 
       if (schema == null) continue;
 
-      // Check for validator usage BEFORE auto-generating path parameters,
-      // so we only detect params from actual validator() calls
-      const hasValidation =
-        schema.requestBody ||
-        (schema.parameters && schema.parameters.length > 0);
+      // A `validator()` middleware marks its operation with VALIDATION_MARKER.
+      // Only routes with an actual validator get the auto-injected 400 — a
+      // manually documented `requestBody`/`parameters` in `describeRoute` (or
+      // auto-generated path params) must NOT trigger it.
+      const hasValidation = schema[VALIDATION_MARKER] === true;
+      delete schema[VALIDATION_MARKER];
 
       if (key.includes("{")) {
         // Clone the parameters array to avoid mutating shared references

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -325,10 +325,15 @@ export function removeExcludedPaths(
       ) {
         const errorResponse = ctx.options.defaultValidationErrorResponse;
 
+        // Clone so each route owns its own response object — the same
+        // default/custom object would otherwise be shared (by reference)
+        // across every validator route (and the module-level default).
         if (typeof errorResponse === "object") {
-          schema.responses["400"] = errorResponse;
+          schema.responses["400"] = structuredClone(errorResponse);
         } else if (ctx.validationErrorResponse) {
-          schema.responses["400"] = ctx.validationErrorResponse;
+          schema.responses["400"] = structuredClone(
+            ctx.validationErrorResponse,
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

- Automatically includes a 400 validation error response in the OpenAPI spec for routes that use `validator()`
- The default 400 response schema matches `@hono/standard-validator`'s error output format: `{ success: false, error: <issues>, data: <input> }`
- Configurable via `defaultValidationErrorResponse` option: `true` (default), `false` (disable), or a custom `ResponseObject`
- User-defined 400 responses in `describeRoute` take precedence over the auto-generated one

Closes #88
Closes #80

## How it works

The 400 injection runs as a post-processing step in `removeExcludedPaths`. It checks each route's merged spec:
1. If the route has `requestBody` or `parameters` from an actual `validator()` call (auto-generated path params don't trigger it)
2. And no existing `400` response
3. Then inject the default validation error response

## Usage

```ts
// Default behavior — 400 auto-included for routes with validator()
const specs = await generateSpecs(app);

// Disable auto-400
const specs = await generateSpecs(app, {
  defaultValidationErrorResponse: false,
});

// Custom 400 response
const specs = await generateSpecs(app, {
  defaultValidationErrorResponse: {
    description: "Bad Request",
    content: { "application/json": { schema: { type: "object" } } },
  },
});
```