### PR TITLE
👋Shortands are fucked 

### DIFF
--- a/src/__tests__/zodv4.test.ts
+++ b/src/__tests__/zodv4.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { OpenAPIV3_1 } from "openapi-types";
 import { describe, expect, it } from "vitest";
 import z from "zod/v4";
 import { generateSpecs } from "../handler.js";
@@ -147,6 +148,52 @@ describe("zod v4", () => {
     const specs = await generateSpecs(app);
 
     expect(specs).toMatchSnapshot();
+  });
+
+  it("shorthand json/query in describeRoute uses requestBody/parameters", async () => {
+    const app = new Hono().get(
+      "/",
+      describeRoute({
+        tags: ["test"],
+        summary: "Test route",
+        description: "This is a test route",
+        json: resolver(z.object({ message: z.string() })),
+        query: resolver(z.object({ search: z.string() })),
+      }),
+      async (c) => {
+        return c.json({ message: "Hello, world!" });
+      },
+    );
+
+    const specs = await generateSpecs(app);
+
+    const operation = specs.paths["/"]?.get;
+
+    expect(operation).toBeDefined();
+    expect(operation).not.toHaveProperty("json");
+    expect(operation).not.toHaveProperty("query");
+
+    const requestBody = operation?.requestBody as OpenAPIV3_1.RequestBodyObject;
+    expect(requestBody).toBeDefined();
+
+    expect(requestBody.content?.["application/json"]?.schema).toEqual({
+      properties: {
+        message: { type: "string" },
+      },
+      required: ["message"],
+      type: "object",
+    });
+
+    expect(operation?.parameters).toEqual([
+      {
+        in: "query",
+        name: "search",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+    ]);
   });
 
   it("resolver in documentation.components.responses", async () => {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -222,7 +222,7 @@ async function getSpec(
   middlewareHandler: HandlerUniqueProperty,
   defaultOptions?: Partial<DescribeRouteOptions>,
 ) {
-  // If the middleware handler has a spec, that is decribeRoute middleware
+  // If the middleware handler has a spec, that is describeRoute middleware
   if ("spec" in middlewareHandler) {
     const tmp = {
       ...defaultOptions,
@@ -239,7 +239,10 @@ async function getSpec(
       components = resolved.components;
     }
 
-    return { schema: tmp, components };
+    const normalized = await normalizeDescribeRouteSpec(tmp);
+    components = mergeComponentsObjects(components, normalized.components);
+
+    return { schema: normalized.spec, components };
   }
 
   const result = await middlewareHandler.toOpenAPISchema();
@@ -311,6 +314,118 @@ async function getSpec(
   }
 
   return { schema: docs, components: result.components };
+}
+
+async function normalizeDescribeRouteSpec(spec: DescribeRouteOptions) {
+  const normalizedSpec: DescribeRouteOptions = { ...spec };
+  let components: OpenAPIV3_1.ComponentsObject = {};
+
+  if ("json" in normalizedSpec && normalizedSpec.json != null) {
+    const resolved = await resolveShorthandSchema(normalizedSpec.json);
+    components = mergeComponentsObjects(components, resolved.components);
+
+    normalizedSpec.requestBody = mergeRequestBody(
+      normalizedSpec.requestBody,
+      "application/json",
+      resolved.schema,
+    );
+
+    delete normalizedSpec.json;
+  }
+
+  if ("query" in normalizedSpec && normalizedSpec.query != null) {
+    const resolved = await resolveShorthandSchema(normalizedSpec.query);
+    components = mergeComponentsObjects(components, resolved.components);
+
+    if ("$ref" in resolved.schema) {
+      const ref = resolved.schema.$ref as string;
+      const pos = ref.split("/").pop();
+
+      if (pos && resolved.components?.schemas?.[pos]) {
+        const schema = resolved.components.schemas[pos];
+        const newParameters = generateParameters("query", schema)[0];
+
+        if (!resolved.components.parameters) {
+          resolved.components.parameters = {};
+        }
+
+        resolved.components.parameters[pos] = newParameters;
+        delete resolved.components.schemas[pos];
+
+        normalizedSpec.parameters = [
+          ...(normalizedSpec.parameters ?? []),
+          { $ref: `#/components/parameters/${pos}` },
+        ];
+      }
+    } else {
+      normalizedSpec.parameters = [
+        ...(normalizedSpec.parameters ?? []),
+        ...generateParameters("query", resolved.schema as OpenAPIV3_1.SchemaObject),
+      ];
+    }
+
+    delete normalizedSpec.query;
+  }
+
+  return { spec: normalizedSpec, components };
+}
+
+function isReferenceObject(
+  obj: OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.RequestBodyObject,
+): obj is OpenAPIV3_1.ReferenceObject {
+  return "$ref" in obj;
+}
+
+function mergeRequestBody(
+  current?: OpenAPIV3_1.RequestBodyObject | OpenAPIV3_1.ReferenceObject,
+  media = "application/json",
+  schema?: OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject,
+) {
+  if (current && isReferenceObject(current)) {
+    // If requestBody is a ref, don't merge, preserve it (unable to merge with inline schema).
+    return current;
+  }
+
+  const currentRequestBody = current as OpenAPIV3_1.RequestBodyObject | undefined;
+
+  const content = {
+    ...(currentRequestBody?.content ?? {}),
+    [media]: {
+      ...(currentRequestBody?.content?.[media] ?? {}),
+      schema,
+    },
+  };
+
+  return {
+    ...currentRequestBody,
+    required: currentRequestBody?.required ?? true,
+    content,
+  };
+}
+
+async function resolveShorthandSchema(
+  value: unknown,
+): Promise<{
+  schema: OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject;
+  components: OpenAPIV3_1.ComponentsObject;
+}> {
+  if (
+    value &&
+    typeof value === "object" &&
+    "toOpenAPISchema" in value &&
+    typeof (value as any).toOpenAPISchema === "function"
+  ) {
+    const result = await (value as any).toOpenAPISchema();
+    return {
+      schema: result.schema,
+      components: result.components ?? {},
+    };
+  }
+
+  return {
+    schema: value as OpenAPIV3_1.SchemaObject,
+    components: {},
+  };
 }
 
 function generateParameters(target: string, schema: OpenAPIV3_1.SchemaObject) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,11 @@ export type GenerateSpecOptions = {
 
 type OperationId = string | ((route: RouterRoute) => string);
 
+export type ShorthandSchemaOrResolver =
+  | ResolverReturnType
+  | OpenAPIV3_1.SchemaObject
+  | OpenAPIV3_1.ReferenceObject;
+
 export type DescribeRouteOptions = Omit<
   OpenAPIV3_1.OperationObject,
   "responses" | "operationId"
@@ -127,6 +132,14 @@ export type DescribeRouteOptions = Omit<
   hide?:
     | boolean
     | ((props: { c?: Context; method: string; path: string }) => boolean);
+  /**
+   * Shortcut to describe request body as JSON schema resolver
+   */
+  json?: ShorthandSchemaOrResolver;
+  /**
+   * Shortcut to describe query parameters as resolver
+   */
+  query?: ShorthandSchemaOrResolver;
   /**
    * Responses of the request
    */


### PR DESCRIPTION
**Before fix:**
- `json` shorthand via `json: resolver(Schema)`  generated invalid spec `json: { vendor: "zod" }`
- `query` shorthand via `query: resolver(Schema)` generated invalid spec `query: { vendor: "zod" }`

**After fix:**
- `json` generates a valid requestBody with JSON schema. eg:  
```
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "type": "object",
                "properties": {
```
- `query` generates a valid parameters array with query schema, eg:  
```
        "parameters": [
          {
            "in": "query",
            "name": "search",
            "schema": {
              "type": "string"
            }
          },
```

**Disclaimer:**
> I spent virtually zero effort trying to get a deep understanding of the library's code, and absolutely 💯 vibe-coded this fix.

I LGTM-ed the unit tests, then simply built, copy-pasted the `dist/` into my other project's `./node_modules/hono-openapi/dist`, restarted it, re-gen-ed the spec, copy-pasted that into a swagger editor, saw no errors, called it 🍑

Haven't introduced any typescript errors that weren't already there in the process.

I do not really care about having this merged with my name on it, only that it does get fixed, so I figured this would be better than just opening a whiny issue.

My gift to you:
> bro + token = broken

Probably.  
Someone should give this a proper test before ✅+🔀
🙇‍♂️