### PR TITLE
fix: handle `allOf` in `generateParameters` for query/param schemas

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -314,6 +314,20 @@ async function getSpec(
 }
 
 function generateParameters(target: string, schema: OpenAPIV3_1.SchemaObject) {
+  if (Array.isArray(schema.allOf)) {
+    const merged = schema.allOf.reduce((acc, s) => ({
+      properties: { ...acc.properties, ...s.properties },
+      required: [...(acc.required ?? []), ...(s.required ?? [])],
+    }), { properties: {}, required: [] });
+
+    return generateParameters(target, {
+      type: "object",
+      ...schema,
+      ...merged,
+      allOf: undefined,
+    });
+  }
+
   const parameters: OpenAPIV3_1.ParameterObject[] = [];
 
   for (const [key, value] of Object.entries(schema.properties ?? {})) {


### PR DESCRIPTION
## Problem

When using `z.intersection()` or `.and()` in Zod, the resulting schema generates an `allOf` in the OpenAPI JSON Schema. The `generateParameters` function did not handle this case — it only iterated `schema.properties`, which is `undefined` when `allOf` is present, resulting in an empty `parameters` array.

Minimal reproduction:

```ts
const cityId = z.object({ cityId: z.number() });
const location = z.object({ latitude: z.number(), longitude: z.number() }).partial();

const querySchema = cityId.and(location);
// or: z.intersection(cityId, location)
```

The generated JSON Schema for this is:
```json
{
  "allOf": [
    { "type": "object", "properties": { "cityId": { ... } }, "required": ["cityId"] },
    { "type": "object", "properties": { "latitude": { ... }, "longitude": { ... } } }
  ]
}
```

`generateParameters` received this schema and produced `[]` — no parameters were registered for the route.

## Fix

When `schema.allOf` is present, merge all sub-schemas into a single flat schema before generating parameters:

```js
if (Array.isArray(schema.allOf)) {
  const merged = schema.allOf.reduce((acc, s) => ({
    properties: { ...acc.properties, ...s.properties },
    required: [...(acc.required ?? []), ...(s.required ?? [])],
  }), { properties: {}, required: [] });

  return generateParameters(target, {
    type: "object",
    ...merged,
    ...schema,
    allOf: undefined,
  });
}
```

## Why `.and()` / `z.intersection()` is the correct approach

A workaround might seem to be using `.extend(otherSchema.shape)` instead, but this is not equivalent:

- `.extend(shape)` only copies the raw field definitions — it **silently drops** any `.refine()`, `.superRefine()`, or `.transform()` attached to the merged schema.
- `.and()` / `z.intersection()` composes both schemas fully, preserving all refinements and effects.

Example where `.extend(shape)` loses the refinement:

```ts
const location = z.object({
  latitude: z.number().optional(),
  longitude: z.number().optional(),
}).refine(
  (d) => (d.latitude === undefined) === (d.longitude === undefined),
  { message: "latitude and longitude must be provided together" }
);

// ✗ loses the .refine — only copies { latitude, longitude } fields
const bad = cityId.extend(location.shape);

// ✓ preserves the .refine
const good = cityId.and(location);
```

So `.and()` is semantically correct here and the library should support it.

## Notes

This solution works for the reported case but may not cover all edge cases (e.g. nested `allOf`, conflicting properties, `$ref` inside `allOf` items). It should be reviewed by someone with deeper knowledge of the intended behavior for this function.
