### PR TITLE
fix: preserve zod-derived types in validator() RPC type inference

### DIFF
--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -206,15 +206,11 @@ export function validator<
   I extends Input = {
     in: HasUndefined<In> extends true
       ? {
-          [K in Target]?: In extends ValidationTargets[K]
-            ? In
-            : { [K2 in keyof In]?: ValidationTargets[K][K2] };
-        }
+        [K in Target]?: Out
+      }
       : {
-          [K in Target]: In extends ValidationTargets[K]
-            ? In
-            : { [K2 in keyof In]: ValidationTargets[K][K2] };
-        };
+        [K in Target]: Out
+      };
     out: { [K in Target]: Out };
   },
   V extends I = I,


### PR DESCRIPTION
## Problem

The **validator()** function's **I** type parameter maps each field value through  **ValidationTargets[K][K2]**, which flattens all Zod-derived types to the target's base type. For query targets this becomes string | string[], for json targets it becomes unknown, etc.

This breaks Hono RPC client type inference — it's lose autocomplete for valid field values. For example:

```ts
// Schema: sortBy is z.enum(["name", "type", "isActive", "createdAt"])
validator("query", schema)
// RPC client sees:  sortBy?: string | string[]
// Expected:         sortBy?: "name" | "type" | "isActive" | "createdAt"
```

## Fix

Replace the **{ [K2 in keyof In]: ValidationTargets[K][K2] }** mapped type with Out (the schema's output type) directly. This matches the approach used by @hono/zod-validator's **zValidator()**.

```ts
I extends Input = {
    in: HasUndefined<In> extends true
-     ? { [K in Target]?: In extends ValidationTargets[K]
-         ? In
-         : { [K2 in keyof In]?: ValidationTargets[K][K2] } }
-     : { [K in Target]: In extends ValidationTargets[K]
-         ? In
-         : { [K2 in keyof In]: ValidationTargets[K][K2] } };
+     ? { [K in Target]?: Out }
+     : { [K in Target]: Out };
    out: { [K in Target]: Out };
};
```

- Type-only change — no runtime code was modified. The sValidator() call and OpenAPI spec registration via uniqueSymbol are unchanged.
- The out type is unchanged — handlers still receive correctly-typed validated data via c.req.valid().
- OpenAPI spec generation is unaffected — request schemas are registered separately via the uniqueSymbol metadata, not from the I type.
- Matches zValidator's approach — @hono/zod-validator has used direct Zod output types since its inception without issues.