### PR TITLE
feat: support HTTP QUERY method (RFC 10008) and bump to OpenAPI 3.2

### DIFF
--- a/src/__tests__/__snapshots__/arktype.test.ts.snap
+++ b/src/__tests__/__snapshots__/arktype.test.ts.snap
@@ -8,7 +8,7 @@ exports[`arktype > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -71,7 +71,7 @@ exports[`arktype > morph schema in json body without explicit fallback 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "post": {
@@ -113,7 +113,7 @@ exports[`arktype > morph schema in param without explicit fallback 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/users/{id}": {
       "get": {
@@ -161,7 +161,7 @@ exports[`arktype > with metadata 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -216,7 +216,7 @@ exports[`arktype > with options 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {

--- a/src/__tests__/__snapshots__/basic.test.ts.snap
+++ b/src/__tests__/__snapshots__/basic.test.ts.snap
@@ -8,7 +8,7 @@ exports[`basic > composed handler 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -67,7 +67,7 @@ exports[`basic > hide with a boolean value 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {},
   "tags": undefined,
 }
@@ -81,7 +81,7 @@ exports[`basic > hide with a function 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {},
   "tags": undefined,
 }

--- a/src/__tests__/__snapshots__/effect.test.ts.snap
+++ b/src/__tests__/__snapshots__/effect.test.ts.snap
@@ -8,7 +8,7 @@ exports[`effect > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -84,7 +84,7 @@ exports[`effect > with reference in parameter 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {

--- a/src/__tests__/__snapshots__/sury.test.ts.snap
+++ b/src/__tests__/__snapshots__/sury.test.ts.snap
@@ -8,7 +8,7 @@ exports[`sury > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -99,7 +99,7 @@ exports[`sury > with metadata 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {

--- a/src/__tests__/__snapshots__/typebox.test.ts.snap
+++ b/src/__tests__/__snapshots__/typebox.test.ts.snap
@@ -8,7 +8,7 @@ exports[`typebox > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -71,7 +71,7 @@ exports[`typebox > with JSON Schema 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -156,7 +156,7 @@ exports[`typebox > with metadata 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {

--- a/src/__tests__/__snapshots__/valibot.test.ts.snap
+++ b/src/__tests__/__snapshots__/valibot.test.ts.snap
@@ -8,7 +8,7 @@ exports[`valibot > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -85,7 +85,7 @@ exports[`valibot > with metadata 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -140,7 +140,7 @@ exports[`valibot > with transformation 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {

--- a/src/__tests__/__snapshots__/zodv3.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv3.test.ts.snap
@@ -8,7 +8,7 @@ exports[`zod v3 > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -82,7 +82,7 @@ exports[`zod v3 > describeResponse 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/{id}": {
       "get": {
@@ -166,7 +166,7 @@ exports[`zod v3 > operation id for path with dash 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/some-path": {
       "get": {
@@ -253,7 +253,7 @@ exports[`zod v3 > with metadata 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -319,7 +319,7 @@ exports[`zod v3 > with reference in parameter 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/{id}": {
       "get": {

--- a/src/__tests__/__snapshots__/zodv4.test.ts.snap
+++ b/src/__tests__/__snapshots__/zodv4.test.ts.snap
@@ -8,7 +8,7 @@ exports[`zod v4 > basic 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -71,7 +71,7 @@ exports[`zod v4 > with global validator 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -129,7 +129,7 @@ exports[`zod v4 > with metadata 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {
@@ -198,7 +198,7 @@ exports[`zod v4 > with response description 1`] = `
     "title": "Hono Documentation",
     "version": "0.0.0",
   },
-  "openapi": "3.1.0",
+  "openapi": "3.2.0",
   "paths": {
     "/": {
       "get": {

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -220,3 +220,24 @@ describe("basic", () => {
     expect(specs).toMatchSnapshot();
   });
 });
+
+describe("QUERY method (RFC 10008 / OpenAPI 3.2)", () => {
+  it("should include QUERY routes in generated spec", async () => {
+    const app = new Hono().on(
+      "QUERY",
+      "/api/wait",
+      describeRoute({
+        description: "Search-style query endpoint",
+        responses: { 200: { description: "Results" } },
+      }),
+      async (c) => c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+    expect(specs.openapi).toBe("3.2.0");
+    expect(specs.paths["/api/wait"]?.query).toBeDefined();
+    expect(specs.paths["/api/wait"]?.query?.description).toBe(
+      "Search-style query endpoint",
+    );
+  });
+});

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -117,7 +117,7 @@ export async function generateSpecs<
   );
 
   return {
-    openapi: "3.1.0",
+    openapi: "3.2.0",
     ..._documentation,
     tags: _documentation.tags?.filter(
       (tag) => !ctx.options.excludeTags?.includes(tag?.name),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ export const ALLOWED_METHODS = [
   "HEAD",
   "PATCH",
   "TRACE",
+  "QUERY",
 ] as const;
 
 export type AllowedMethods = (typeof ALLOWED_METHODS)[number];
@@ -191,7 +192,6 @@ export function registerSchemaPath({
     }
 
     if (paths[path]) {
-      // @ts-expect-error
       paths[path][method] = mergeSpecs(
         route,
         ...pathContext,


### PR DESCRIPTION
## Summary

Adds support for the HTTP `QUERY` method (standardized in [RFC 10008](https://datatracker.ietf.org/doc/html/rfc10008)) and bumps the generated OpenAPI version from 3.1.0 to 3.2.0.

Closes #237.

## Changes

- **`src/utils.ts`**: Added `"QUERY"` to the `ALLOWED_METHODS` array so that Hono routes defined with `app.on("QUERY", ...)` are included in generated OpenAPI specs instead of being silently skipped.
- **`src/handler.ts`**: Bumped `openapi` field from `"3.1.0"` to `"3.2.0"` since QUERY is a first-class path-item operation in OpenAPI 3.2 (backward-compatible with 3.1 — same JSON Schema draft).
- **`src/__tests__/basic.test.ts`**: Added test that a `QUERY` route appears in the generated spec with a `query` operation key.
- **Snapshot files**: Updated all `"openapi": "3.1.0"` references to `"3.2.0"` across 8 snapshot files.

## Verification

- `pnpm test` — 49/49 tests pass, no type errors.