### PR TITLE
Allow @hono/standard-validator 0.3 as a peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     }
   },
   "peerDependencies": {
-    "@hono/standard-validator": "^0.2.0",
+    "@hono/standard-validator": "^0.2.0 || ^0.3.0",
     "@standard-community/standard-json": "^0.3.5",
     "@standard-community/standard-openapi": "^0.2.9",
     "@types/json-schema": "^7.0.15",
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",
+    "@hono/standard-validator": "^0.3.0",
     "@standard-schema/spec": "^1.0.0",
     "@valibot/to-json-schema": "^1.3.0",
     "arktype": "^2.1.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@hono/standard-validator':
-        specifier: ^0.2.0
-        version: 0.2.3(@standard-schema/spec@1.0.0)(hono@4.12.27)
       '@standard-community/standard-json':
         specifier: ^0.3.5
         version: 0.3.5(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.22)(effect@3.17.13)(quansync@0.2.11)(sury@10.0.4)(typebox@1.0.17)(valibot@1.1.0(typescript@5.8.3))(zod@3.25.76)
@@ -30,6 +27,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.0.6
         version: 2.0.6
+      '@hono/standard-validator':
+        specifier: ^0.3.0
+        version: 0.3.0(@standard-schema/spec@1.0.0)(hono@4.12.27)
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
@@ -306,11 +306,11 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@hono/standard-validator@0.2.3':
-    resolution: {integrity: sha512-bp9vHu6Va6SfMHC3D4ZLBbT/woi+AZ9CRdTXQu3kLJuLh2W/Gb9UO4hijS+BQAGFXi4EGpXdetxpzwTAawSVeg==}
+  '@hono/standard-validator@0.3.0':
+    resolution: {integrity: sha512-tHLKEjKXDcHImj0XTFWW4Hr0ev+1G5GxnBZrGdpg/7NLy9s9meFPTSCOkw++ZzZKom3FjrMw2e0nFQpPPvwUVQ==}
     peerDependencies:
       '@standard-schema/spec': ^1.0.0
-      hono: '>=3.9.0'
+      hono: '>=4.11.2'
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -1329,7 +1329,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@hono/standard-validator@0.2.3(@standard-schema/spec@1.0.0)(hono@4.12.27)':
+  '@hono/standard-validator@0.3.0(@standard-schema/spec@1.0.0)(hono@4.12.27)':
     dependencies:
       '@standard-schema/spec': 1.0.0
       hono: 4.12.27


### PR DESCRIPTION
## Summary
- widen the peer range to recognise `@hono/standard-validator` 0.3 whilst retaining 0.2 support
- run the test suite against 0.3 to prevent the supported range from drifting again

Closes #239

## Test plan
- [x] `pnpm test --run`
- [x] `pnpm build`

Made with [Cursor](https://cursor.com)