### PR TITLE
fix(openapi): Generate parameters from allOf schemas

### DIFF
--- a/src/__tests__/zodv4.test.ts
+++ b/src/__tests__/zodv4.test.ts
@@ -304,6 +304,49 @@ describe("zod v4", () => {
     expect(worldParams?.[0]).toMatchObject({ name: "greeting", in: "query" });
   });
 
+  it("generates parameters for nested intersection query schemas", async () => {
+    const filters = z.intersection(
+      z.object({ search: z.string().min(1) }),
+      z.intersection(
+        z.object({ search: z.string().max(100), page: z.coerce.number() }),
+        z.object({ includeArchived: z.coerce.boolean().optional() }),
+      ),
+    );
+
+    const app = new Hono().get("/", validator("query", filters), (c) =>
+      c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+    const parameters = specs.paths["/"]?.get?.parameters ?? [];
+    const queryParameters = parameters.filter(
+      (parameter) => "name" in parameter && parameter.in === "query",
+    );
+
+    expect(queryParameters).toHaveLength(3);
+    expect(queryParameters.map((parameter) => parameter.name)).toEqual([
+      "search",
+      "page",
+      "includeArchived",
+    ]);
+    expect(queryParameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "search", required: true }),
+        expect.objectContaining({ name: "page", required: true }),
+        expect.objectContaining({ name: "includeArchived" }),
+      ]),
+    );
+    const search = queryParameters.find(
+      (parameter) => parameter.name === "search",
+    );
+    expect(search && "schema" in search && search.schema).toMatchObject({
+      allOf: [
+        expect.objectContaining({ minLength: 1 }),
+        expect.objectContaining({ maxLength: 100 }),
+      ],
+    });
+  });
+
   it("validator should set requestBody.required to true", async () => {
     const app = new Hono().post(
       "/",

--- a/src/__tests__/zodv4.test.ts
+++ b/src/__tests__/zodv4.test.ts
@@ -347,6 +347,30 @@ describe("zod v4", () => {
     });
   });
 
+  it("generates parameters for referenced intersection query schemas", async () => {
+    const filters = z.intersection(
+      z.object({ search: z.string() }).meta({ ref: "SearchFilter" }),
+      z.object({ page: z.coerce.number() }).meta({ ref: "PageFilter" }),
+    );
+
+    const app = new Hono().get("/", validator("query", filters), (c) =>
+      c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+    const parameters = specs.paths["/"]?.get?.parameters ?? [];
+    const queryParameters = parameters.filter(
+      (parameter) => "name" in parameter && parameter.in === "query",
+    );
+
+    expect(queryParameters.map((parameter) => parameter.name)).toEqual([
+      "search",
+      "page",
+    ]);
+    expect(specs.components?.schemas?.SearchFilter).toBeDefined();
+    expect(specs.components?.schemas?.PageFilter).toBeDefined();
+  });
+
   it("validator should set requestBody.required to true", async () => {
     const app = new Hono().post(
       "/",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -337,7 +337,11 @@ async function getSpec(
         });
       }
     } else {
-      parameters = generateParameters(middlewareHandler.target, result.schema);
+      parameters = generateParameters(
+        middlewareHandler.target,
+        result.schema,
+        result.components?.schemas,
+      );
     }
 
     docs.parameters = parameters;
@@ -346,10 +350,14 @@ async function getSpec(
   return { schema: docs, components: result.components };
 }
 
-function generateParameters(target: string, schema: OpenAPIV3_1.SchemaObject) {
+function generateParameters(
+  target: string,
+  schema: OpenAPIV3_1.SchemaObject,
+  schemas?: OpenAPIV3_1.ComponentsObject["schemas"],
+) {
   const parameters: OpenAPIV3_1.ParameterObject[] = [];
 
-  for (const [key, property] of collectParameterProperties(schema)) {
+  for (const [key, property] of collectParameterProperties(schema, schemas)) {
     const def: OpenAPIV3_1.ParameterObject = {
       in: target === "param" ? "path" : target,
       name: key,
@@ -372,7 +380,10 @@ function generateParameters(target: string, schema: OpenAPIV3_1.SchemaObject) {
   return parameters;
 }
 
-function collectParameterProperties(schema: OpenAPIV3_1.SchemaObject) {
+function collectParameterProperties(
+  schema: OpenAPIV3_1.SchemaObject,
+  schemas?: OpenAPIV3_1.ComponentsObject["schemas"],
+) {
   const properties = new Map<
     string,
     {
@@ -381,6 +392,7 @@ function collectParameterProperties(schema: OpenAPIV3_1.SchemaObject) {
     }
   >();
 
+  const resolvingRefs = new Set<string>();
   const collect = (current: OpenAPIV3_1.SchemaObject) => {
     for (const [key, value] of Object.entries(current.properties ?? {})) {
       const existing = properties.get(key);
@@ -392,7 +404,21 @@ function collectParameterProperties(schema: OpenAPIV3_1.SchemaObject) {
     }
 
     for (const member of current.allOf ?? []) {
-      if (!("$ref" in member)) {
+      if ("$ref" in member) {
+        const prefix = "#/components/schemas/";
+        if (!member.$ref.startsWith(prefix)) continue;
+
+        const name = member.$ref
+          .slice(prefix.length)
+          .replaceAll("~1", "/")
+          .replaceAll("~0", "~");
+        const referencedSchema = schemas?.[name];
+        if (referencedSchema && !resolvingRefs.has(name)) {
+          resolvingRefs.add(name);
+          collect(referencedSchema);
+          resolvingRefs.delete(name);
+        }
+      } else {
         collect(member);
       }
     }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -349,29 +349,57 @@ async function getSpec(
 function generateParameters(target: string, schema: OpenAPIV3_1.SchemaObject) {
   const parameters: OpenAPIV3_1.ParameterObject[] = [];
 
-  for (const [key, value] of Object.entries(schema.properties ?? {})) {
+  for (const [key, property] of collectParameterProperties(schema)) {
     const def: OpenAPIV3_1.ParameterObject = {
       in: target === "param" ? "path" : target,
       name: key,
-      // @ts-expect-error
-      schema: value,
+      // @ts-expect-error ParameterObject uses the OpenAPI 3.0 schema type.
+      schema: property.schema,
     };
 
-    const isRequired = schema.required?.includes(key);
-
-    if (isRequired) {
+    if (property.required) {
       def.required = true;
     }
 
     if (def.schema && "description" in def.schema && def.schema.description) {
       def.description = def.schema.description;
-      def.schema.description = undefined;
+      def.schema = { ...def.schema, description: undefined };
     }
 
     parameters.push(def);
   }
 
   return parameters;
+}
+
+function collectParameterProperties(schema: OpenAPIV3_1.SchemaObject) {
+  const properties = new Map<
+    string,
+    {
+      schema: OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.SchemaObject;
+      required: boolean;
+    }
+  >();
+
+  const collect = (current: OpenAPIV3_1.SchemaObject) => {
+    for (const [key, value] of Object.entries(current.properties ?? {})) {
+      const existing = properties.get(key);
+      properties.set(key, {
+        schema: existing ? { allOf: [existing.schema, value] } : value,
+        required:
+          Boolean(current.required?.includes(key)) || existing?.required,
+      });
+    }
+
+    for (const member of current.allOf ?? []) {
+      if (!("$ref" in member)) {
+        collect(member);
+      }
+    }
+  };
+
+  collect(schema);
+  return properties;
 }
 
 /**


### PR DESCRIPTION
Nested `allOf` schemas from intersection-based query validation now emit one parameter per property. Repeated properties preserve both validation constraints with a parameter-level `allOf` instead of losing a constraint or creating duplicate parameters.
