### PR TITLE
fix: Harden schema generation with adapter behavior tests

### DIFF
--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -567,21 +567,6 @@ describe("default validation error response", () => {
     expect(JSON.stringify(op)).not.toContain("HonoOpenAPIValidator");
   });
 
-  it("should inject a single 400 when multiple validators are on one route", async () => {
-    const app = new Hono().post(
-      "/",
-      validator("json", z.object({ a: z.string() })),
-      validator("query", z.object({ b: z.string() })),
-      async (c) => c.json({ ok: true }),
-    );
-
-    const specs = await generateSpecs(app);
-
-    const responses = specs.paths["/"]?.post?.responses ?? {};
-    expect(responses["400"]).toBeDefined();
-    expect(Object.keys(responses).filter((k) => k === "400")).toHaveLength(1);
-  });
-
   it("should give each validator route its own 400 object (no shared reference)", async () => {
     const app = new Hono()
       .post("/a", validator("json", z.object({ a: z.string() })), (c) =>
@@ -615,21 +600,5 @@ describe("default validation error response", () => {
     });
 
     expect(specs.paths["/"]?.post?.responses?.["400"]).toEqual(ref);
-  });
-
-  it("should mark data as required in the default validation error schema", async () => {
-    // @hono/standard-validator always returns { success, error, data } on a
-    // validation error, so all three are required.
-    const app = new Hono().post(
-      "/",
-      validator("json", z.object({ a: z.string() })),
-      (c) => c.json({ ok: true }),
-    );
-
-    const specs = await generateSpecs(app);
-
-    const schema = (specs.paths["/"]?.post?.responses?.["400"] as any)
-      ?.content?.["application/json"]?.schema;
-    expect(schema?.required).toEqual(["success", "error", "data"]);
   });
 });

--- a/src/__tests__/generation.test.ts
+++ b/src/__tests__/generation.test.ts
@@ -1,0 +1,181 @@
+import { Schema } from "effect";
+import { Hono } from "hono";
+import type { OpenAPIV3_1 } from "openapi-types";
+import { describe, expect, it } from "vitest";
+import z from "zod/v4";
+import {
+  describeRoute,
+  generateSpecs,
+  openAPIRouteHandler,
+  resolver,
+  validator,
+} from "../index.js";
+
+describe("request body media", () => {
+  it.each([
+    { target: "json", media: undefined, expected: "application/json" },
+    { target: "form", media: undefined, expected: "multipart/form-data" },
+    {
+      target: "form",
+      media: "application/x-www-form-urlencoded",
+      expected: "application/x-www-form-urlencoded",
+    },
+    {
+      target: "json",
+      media: "application/vnd.api+json",
+      expected: "application/vnd.api+json",
+    },
+  ] as const)(
+    "documents $target with media $media as $expected",
+    async ({ target, media, expected }) => {
+      const app = new Hono().post(
+        "/users",
+        validator(target, z.object({ name: z.string() }), undefined, { media }),
+        (c) => c.json(c.req.valid(target)),
+      );
+      const specs = await generateSpecs(app);
+      const body = specs.paths["/users"]?.post?.requestBody;
+      if (!body || !("content" in body))
+        throw new Error("Missing request body");
+      expect(Object.keys(body.content)).toEqual([expected]);
+      expect(body.content[expected].schema).toMatchObject({
+        properties: { name: { type: "string" } },
+      });
+
+      const requestBody =
+        expected === "multipart/form-data"
+          ? new FormData()
+          : expected === "application/x-www-form-urlencoded"
+            ? "name=Ada"
+            : JSON.stringify({ name: "Ada" });
+      if (requestBody instanceof FormData) requestBody.set("name", "Ada");
+      const response = await app.request("/users", {
+        method: "POST",
+        headers:
+          requestBody instanceof FormData
+            ? undefined
+            : { "content-type": expected },
+        body: requestBody,
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ name: "Ada" });
+    },
+  );
+});
+
+describe("named parameter schemas", () => {
+  it.each([
+    {
+      name: "Zod",
+      schema: z
+        .object({ name: z.string(), age: z.string().optional() })
+        .meta({ ref: "Filters" }),
+    },
+    {
+      name: "Effect",
+      schema: Schema.standardSchemaV1(
+        Schema.Struct({
+          name: Schema.String,
+          age: Schema.optional(Schema.String),
+        }).annotations({ identifier: "Filters" }),
+      ),
+    },
+    {
+      name: "referenced intersection",
+      schema: z
+        .intersection(
+          z.object({ name: z.string() }).meta({ ref: "Name" }),
+          z.object({ age: z.string().optional() }).meta({ ref: "Age" }),
+        )
+        .meta({ ref: "Filters" }),
+    },
+  ])("keeps every field and its optionality for $name", async ({ schema }) => {
+    const app = new Hono().get("/users", validator("query", schema), (c) =>
+      c.json(c.req.valid("query")),
+    );
+    const specs = await generateSpecs(app);
+    const parameters = specs.paths["/users"]?.get?.parameters?.map(
+      (parameter) => {
+        if (!("$ref" in parameter)) return parameter;
+        const key = parameter.$ref.slice("#/components/parameters/".length);
+        return specs.components?.parameters?.[key];
+      },
+    ) as OpenAPIV3_1.ParameterObject[];
+    expect(parameters).toHaveLength(2);
+    expect(parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          in: "query",
+          name: "name",
+          required: true,
+          schema: { type: "string" },
+        }),
+        expect.objectContaining({
+          in: "query",
+          name: "age",
+          schema: { type: "string" },
+        }),
+      ]),
+    );
+    expect(parameters.find((p) => p.name === "age")?.required).not.toBe(true);
+  });
+});
+
+describe("generation lifecycle", () => {
+  it("isolates middleware metadata when two apps generate specs concurrently", async () => {
+    const createApp = (tag: string) =>
+      new Hono()
+        .use("/api/*", describeRoute({ tags: [tag] }))
+        .get(
+          "/api/items",
+          validator("query", z.object({ q: z.string() })),
+          (c) => c.json(c.req.valid("query")),
+        )
+        .get("/api/plain", (c) => c.json({ ok: true }));
+    const leftApp = createApp("left");
+    const rightApp = createApp("right");
+    // First conversion is asynchronous; both apps register middleware before
+    // their endpoint schemas finish. No sleeps or timing thresholds needed.
+    const [left, right] = await Promise.all([
+      generateSpecs(leftApp, { includeEmptyPaths: true }),
+      generateSpecs(rightApp, { includeEmptyPaths: true }),
+    ]);
+    expect(left.paths["/api/items"]?.get?.tags).toEqual(["left"]);
+    expect(right.paths["/api/items"]?.get?.tags).toEqual(["right"]);
+    expect(left.paths["/api/plain"]?.get?.tags).toEqual(["left"]);
+    expect(right.paths["/api/plain"]?.get?.tags).toEqual(["right"]);
+    expect(await generateSpecs(leftApp, { includeEmptyPaths: true })).toEqual(
+      left,
+    );
+  });
+
+  it("serves complete references on repeated requests with a recreated OpenAPI handler", async () => {
+    const user = z.object({ name: z.string() }).meta({ ref: "User" });
+    const app = new Hono().get(
+      "/users",
+      describeRoute({
+        responses: {
+          200: {
+            description: "Users",
+            content: {
+              "application/json": { schema: resolver(z.array(user)) },
+            },
+          },
+        },
+      }),
+      (c) => c.json([{ name: "Ada" }]),
+    );
+    app.get("/openapi.json", (c, next) => openAPIRouteHandler(app)(c, next));
+    const first = await (await app.request("/openapi.json")).json();
+    const second = await (await app.request("/openapi.json")).json();
+    expect(first).toEqual(second);
+    expect(
+      second.paths["/users"].get.responses[200].content["application/json"]
+        .schema,
+    ).toEqual({ type: "array", items: { $ref: "#/components/schemas/User" } });
+    expect(second.components.schemas.User).toMatchObject({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+  });
+});

--- a/src/__tests__/generation.test.ts
+++ b/src/__tests__/generation.test.ts
@@ -13,7 +13,6 @@ import {
 
 describe("request body media", () => {
   it.each([
-    { target: "json", media: undefined, expected: "application/json" },
     { target: "form", media: undefined, expected: "multipart/form-data" },
     {
       target: "form",
@@ -66,12 +65,6 @@ describe("request body media", () => {
 describe("named parameter schemas", () => {
   it.each([
     {
-      name: "Zod",
-      schema: z
-        .object({ name: z.string(), age: z.string().optional() })
-        .meta({ ref: "Filters" }),
-    },
-    {
       name: "Effect",
       schema: Schema.standardSchemaV1(
         Schema.Struct({
@@ -118,6 +111,45 @@ describe("named parameter schemas", () => {
       ]),
     );
     expect(parameters.find((p) => p.name === "age")?.required).not.toBe(true);
+  });
+
+  it("keeps query and header parameters distinct when they share a named object", async () => {
+    const filters = z
+      .object({ name: z.string(), age: z.string().optional() })
+      .meta({ ref: "Filters" });
+    const app = new Hono().get(
+      "/users",
+      validator("query", filters),
+      validator("header", filters),
+      (c) =>
+        c.json({ query: c.req.valid("query"), header: c.req.valid("header") }),
+    );
+    const specs = await generateSpecs(app);
+    const parameters = specs.paths["/users"]?.get?.parameters?.map(
+      (parameter) => {
+        if (!("$ref" in parameter)) return parameter;
+        return specs.components?.parameters?.[
+          parameter.$ref.slice("#/components/parameters/".length)
+        ];
+      },
+    );
+    expect(parameters).toHaveLength(4);
+    expect(parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ in: "query", name: "name", required: true }),
+        expect.objectContaining({ in: "header", name: "name", required: true }),
+        expect.objectContaining({ in: "query", name: "age" }),
+        expect.objectContaining({ in: "header", name: "age" }),
+      ]),
+    );
+    const response = await app.request("/users?name=query", {
+      headers: { name: "header" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      query: { name: "query" },
+      header: { name: "header" },
+    });
   });
 });
 

--- a/src/__tests__/generation.test.ts
+++ b/src/__tests__/generation.test.ts
@@ -113,44 +113,70 @@ describe("named parameter schemas", () => {
     expect(parameters.find((p) => p.name === "age")?.required).not.toBe(true);
   });
 
-  it("keeps query and header parameters distinct when they share a named object", async () => {
-    const filters = z
-      .object({ name: z.string(), age: z.string().optional() })
-      .meta({ ref: "Filters" });
-    const app = new Hono().get(
-      "/users",
-      validator("query", filters),
-      validator("header", filters),
-      (c) =>
-        c.json({ query: c.req.valid("query"), header: c.req.valid("header") }),
-    );
-    const specs = await generateSpecs(app);
-    const parameters = specs.paths["/users"]?.get?.parameters?.map(
-      (parameter) => {
-        if (!("$ref" in parameter)) return parameter;
-        return specs.components?.parameters?.[
-          parameter.$ref.slice("#/components/parameters/".length)
-        ];
-      },
-    );
-    expect(parameters).toHaveLength(4);
-    expect(parameters).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ in: "query", name: "name", required: true }),
-        expect.objectContaining({ in: "header", name: "name", required: true }),
-        expect.objectContaining({ in: "query", name: "age" }),
-        expect.objectContaining({ in: "header", name: "age" }),
-      ]),
-    );
-    const response = await app.request("/users?name=query", {
-      headers: { name: "header" },
-    });
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      query: { name: "query" },
-      header: { name: "header" },
-    });
-  });
+  it.each([
+    {
+      name: "one-field",
+      schema: z.object({ name: z.string() }),
+      expected: [
+        { in: "query", name: "name", required: true },
+        { in: "header", name: "name", required: true },
+      ],
+    },
+    {
+      name: "multi-field",
+      schema: z.object({ name: z.string(), age: z.string().optional() }),
+      expected: [
+        { in: "query", name: "name", required: true },
+        { in: "header", name: "name", required: true },
+        { in: "query", name: "age", required: false },
+        { in: "header", name: "age", required: false },
+      ],
+    },
+  ])(
+    "keeps query and header parameters distinct for a shared $name object",
+    async ({ schema, expected }) => {
+      const filters = schema.meta({ ref: "Filters" });
+      const app = new Hono().get(
+        "/users",
+        validator("query", filters),
+        validator("header", filters),
+        (c) =>
+          c.json({
+            query: c.req.valid("query"),
+            header: c.req.valid("header"),
+          }),
+      );
+      const specs = await generateSpecs(app);
+      const parameters = specs.paths["/users"]?.get?.parameters?.map(
+        (parameter) => {
+          if (!("$ref" in parameter)) return parameter;
+          return specs.components?.parameters?.[
+            parameter.$ref.slice("#/components/parameters/".length)
+          ];
+        },
+      );
+      expect(parameters).toHaveLength(expected.length);
+      expect(
+        parameters?.map((parameter) => {
+          if (!parameter || !("in" in parameter))
+            throw new Error("Missing parameter definition");
+          return {
+            in: parameter.in,
+            name: parameter.name,
+            required: parameter.required ?? false,
+          };
+        }),
+      ).toEqual(expect.arrayContaining(expected));
+      const response = await app.request("/users?name=query", {
+        headers: { name: "header" },
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        query: { name: "query" },
+        header: { name: "header" },
+      });
+    },
+  );
 });
 
 describe("generation lifecycle", () => {

--- a/src/__tests__/schema-compatibility.test.ts
+++ b/src/__tests__/schema-compatibility.test.ts
@@ -130,16 +130,12 @@ describe.each(vendors)("$name request contract", ({ schema, nullable }) => {
       expect(response.status).toBe(400);
       const result = await response.json();
       expect(result).toMatchObject({ success: false, data: input });
-      expect(result.error.length).toBeGreaterThan(0);
+      expect(result.error).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.any(String) }),
+        ]),
+      );
     }
     expect(handled).toBe(false);
-    const specs = await generateSpecs(app);
-    expect(specs.paths["/users"]?.post?.responses?.[400]).toMatchObject({
-      content: {
-        "application/json": {
-          schema: { required: ["success", "error", "data"] },
-        },
-      },
-    });
   });
 });

--- a/src/__tests__/schema-compatibility.test.ts
+++ b/src/__tests__/schema-compatibility.test.ts
@@ -1,0 +1,145 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { type } from "arktype";
+import { Schema } from "effect";
+import { Hono } from "hono";
+import * as S from "sury";
+import Type from "typebox";
+import { Compile } from "typebox/compile";
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import z3 from "zod";
+import z4 from "zod/v4";
+import { generateSpecs, validator } from "../index.js";
+
+// Equivalent inputs, expressed in each vendor's own schema API. Keep the
+// expectations about HTTP behavior and documentation shared across adapters.
+const vendors = [
+  {
+    name: "Zod 3",
+    schema: z3.object({
+      name: z3.string(),
+      alias: z3.string().optional(),
+      note: z3.string().nullable(),
+    }),
+    nullable: { type: ["string", "null"] },
+  },
+  {
+    name: "Zod 4",
+    schema: z4.object({
+      name: z4.string(),
+      alias: z4.string().optional(),
+      note: z4.string().nullable(),
+    }),
+    nullable: { anyOf: [{ type: "string" }, { type: "null" }] },
+  },
+  {
+    name: "Valibot",
+    schema: v.object({
+      name: v.string(),
+      alias: v.optional(v.string()),
+      note: v.nullable(v.string()),
+    }),
+    nullable: { anyOf: [{ type: "string" }, { type: "null" }] },
+  },
+  {
+    name: "ArkType",
+    schema: type({ name: "string", "alias?": "string", note: "string | null" }),
+    nullable: { anyOf: [{ type: "string" }, { type: "null" }] },
+  },
+  {
+    name: "Effect",
+    schema: Schema.standardSchemaV1(
+      Schema.Struct({
+        name: Schema.String,
+        alias: Schema.optional(Schema.String),
+        note: Schema.NullOr(Schema.String),
+      }),
+    ),
+    nullable: { anyOf: [{ type: "string" }, { type: "null" }] },
+  },
+  {
+    name: "TypeBox",
+    schema: Compile(
+      Type.Object({
+        name: Type.String(),
+        alias: Type.Optional(Type.String()),
+        note: Type.Union([Type.String(), Type.Null()]),
+      }),
+    ),
+    nullable: { anyOf: [{ type: "string" }, { type: "null" }] },
+  },
+  {
+    name: "Sury",
+    schema: S.schema({
+      name: S.string,
+      alias: S.optional(S.string),
+      note: S.union([S.string, S.schema(null)]),
+    }),
+    nullable: { anyOf: [{ type: "string" }, { type: "null" }] },
+  },
+] satisfies { name: string; schema: StandardSchemaV1; nullable: object }[];
+
+describe.each(vendors)("$name request contract", ({ schema, nullable }) => {
+  it("documents optional and nullable fields without changing validated input", async () => {
+    const app = new Hono().post("/users", validator("json", schema), (c) =>
+      c.json(c.req.valid("json")),
+    );
+    const specs = await generateSpecs(app);
+    const body = specs.paths["/users"]?.post?.requestBody;
+    expect(body).toMatchObject({ required: true });
+    if (!body || !("content" in body)) throw new Error("Missing request body");
+    expect(body.content["application/json"].schema).toMatchObject({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        alias: { type: "string" },
+        note: nullable,
+      },
+    });
+    const jsonSchema = body.content["application/json"].schema;
+    if (!jsonSchema || !("required" in jsonSchema))
+      throw new Error("Missing required fields");
+    expect(jsonSchema.required?.slice().sort()).toEqual(["name", "note"]);
+
+    for (const input of [
+      { name: "Ada", note: null },
+      { name: "Ada", alias: "A", note: "hello" },
+    ]) {
+      const response = await app.request("/users", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(input);
+    }
+  });
+
+  it("rejects missing required fields and wrong types before calling the handler", async () => {
+    let handled = false;
+    const app = new Hono().post("/users", validator("json", schema), (c) => {
+      handled = true;
+      return c.json({ accepted: true });
+    });
+    for (const input of [{ name: "Ada" }, { name: 42, note: null }]) {
+      const response = await app.request("/users", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      expect(response.status).toBe(400);
+      const result = await response.json();
+      expect(result).toMatchObject({ success: false, data: input });
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+    expect(handled).toBe(false);
+    const specs = await generateSpecs(app);
+    expect(specs.paths["/users"]?.post?.responses?.[400]).toMatchObject({
+      content: {
+        "application/json": {
+          schema: { required: ["success", "error", "data"] },
+        },
+      },
+    });
+  });
+});

--- a/src/__tests__/sury.test.ts
+++ b/src/__tests__/sury.test.ts
@@ -90,7 +90,10 @@ describe("sury", () => {
       "/",
       describeResponse(
         (c) => {
-          return c.json({ name: "test", createdAt: new Date() }, 200);
+          return c.json(
+            { name: "test", createdAt: new Date("2026-01-02T03:04:05.000Z") },
+            200,
+          );
         },
         {
           200: {
@@ -105,6 +108,13 @@ describe("sury", () => {
       ),
     );
 
+    const response = await app.request("/");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      name: "test",
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+
     const specs = await generateSpecs(app);
 
     expect(specs.paths["/"]?.get?.responses).toEqual({
@@ -112,7 +122,14 @@ describe("sury", () => {
         description: "OK",
         content: {
           "application/json": {
-            schema: expect.any(Object),
+            schema: expect.objectContaining({
+              properties: expect.objectContaining({
+                createdAt: expect.objectContaining({
+                  type: "string",
+                  format: "date-time",
+                }),
+              }),
+            }),
           },
         },
       },

--- a/src/__tests__/valibot.test.ts
+++ b/src/__tests__/valibot.test.ts
@@ -122,7 +122,7 @@ describe("valibot", () => {
     expect(specs).toMatchSnapshot();
   });
 
-  it("describeResponse with Date schema matches c.json serialization", async () => {
+  it("describeResponse honors a Date override matching c.json serialization", async () => {
     const ResponseSchema = v.object({
       name: v.string(),
       createdAt: v.date(),
@@ -132,7 +132,10 @@ describe("valibot", () => {
       "/",
       describeResponse(
         (c) => {
-          return c.json({ name: "test", createdAt: new Date() }, 200);
+          return c.json(
+            { name: "test", createdAt: new Date("2026-01-02T03:04:05.000Z") },
+            200,
+          );
         },
         {
           200: {
@@ -144,8 +147,30 @@ describe("valibot", () => {
             },
           },
         },
+        {
+          options: {
+            // Valibot dates need an explicit JSON representation.
+            overrideSchema: ({
+              valibotSchema,
+              jsonSchema,
+            }: {
+              valibotSchema: { type: string };
+              jsonSchema: object;
+            }) =>
+              valibotSchema.type === "date"
+                ? { type: "string", format: "date-time" }
+                : jsonSchema,
+          },
+        },
       ),
     );
+
+    const response = await app.request("/");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      name: "test",
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
 
     const specs = await generateSpecs(app);
 
@@ -154,7 +179,14 @@ describe("valibot", () => {
         description: "OK",
         content: {
           "application/json": {
-            schema: expect.any(Object),
+            schema: expect.objectContaining({
+              properties: expect.objectContaining({
+                createdAt: expect.objectContaining({
+                  type: "string",
+                  format: "date-time",
+                }),
+              }),
+            }),
           },
         },
       },

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -1,0 +1,157 @@
+import { type } from "arktype";
+import { Schema } from "effect";
+import { Hono } from "hono";
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import z3 from "zod";
+import z4 from "zod/v4";
+import { generateSpecs, validator } from "../index.js";
+
+describe("transformed query input", () => {
+  it.each([
+    {
+      name: "Zod 3",
+      schema: z3.object({
+        count: z3.string().regex(/^\d+$/).transform(Number),
+      }),
+      options: {},
+    },
+    {
+      name: "Zod 4",
+      schema: z4.object({
+        count: z4.string().regex(/^\d+$/).transform(Number),
+      }),
+      options: {},
+    },
+    {
+      name: "Valibot",
+      schema: v.object({
+        count: v.pipe(
+          v.string(),
+          v.regex(/^\d+$/),
+          v.transform(Number),
+          v.number(),
+        ),
+      }),
+      options: { typeMode: "input" },
+    },
+    {
+      name: "ArkType",
+      schema: type({ count: "string.integer.parse" }),
+      options: {},
+    },
+    {
+      name: "Effect",
+      schema: Schema.standardSchemaV1(
+        Schema.Struct({ count: Schema.NumberFromString }),
+      ),
+      options: {},
+    },
+  ])(
+    "documents the input and passes the parsed output to the handler for $name",
+    async ({ schema, options }) => {
+      const app = new Hono().get(
+        "/count",
+        validator("query", schema, undefined, { options }),
+        (c) => c.json(c.req.valid("query")),
+      );
+      const specs = await generateSpecs(app);
+      expect(specs.paths["/count"]?.get?.parameters).toEqual([
+        expect.objectContaining({
+          name: "count",
+          in: "query",
+          required: true,
+        }),
+      ]);
+      const parameter = specs.paths["/count"]?.get?.parameters?.[0];
+      if (!parameter || !("schema" in parameter) || !parameter.schema) {
+        throw new Error("Missing parameter schema");
+      }
+      const inputSchema =
+        "$ref" in parameter.schema
+          ? specs.components?.schemas?.[
+              parameter.schema.$ref.slice("#/components/schemas/".length)
+            ]
+          : parameter.schema;
+      expect(inputSchema).toMatchObject({ type: "string" });
+      const response = await app.request("/count?count=2");
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ count: 2 });
+      expect((await app.request("/count?count=invalid")).status).toBe(400);
+    },
+  );
+});
+
+describe("default query values", () => {
+  it.each([
+    {
+      name: "Zod 3",
+      schema: z3.object({ sort: z3.enum(["asc", "desc"]).default("asc") }),
+    },
+    {
+      name: "Zod 4",
+      schema: z4.object({ sort: z4.enum(["asc", "desc"]).default("asc") }),
+    },
+    {
+      name: "Valibot",
+      schema: v.object({
+        sort: v.optional(v.picklist(["asc", "desc"]), "asc"),
+      }),
+    },
+  ])(
+    "keeps a defaulted $name field optional in the spec and supplies its runtime default",
+    async ({ schema }) => {
+      const app = new Hono().get("/users", validator("query", schema), (c) =>
+        c.json(c.req.valid("query")),
+      );
+      const specs = await generateSpecs(app);
+      const parameter = specs.paths["/users"]?.get?.parameters?.[0];
+      expect(parameter).toMatchObject({
+        name: "sort",
+        schema: { enum: ["asc", "desc"], default: "asc" },
+      });
+      expect(parameter).not.toMatchObject({ required: true });
+      expect(await (await app.request("/users")).json()).toEqual({
+        sort: "asc",
+      });
+      expect(await (await app.request("/users?sort=desc")).json()).toEqual({
+        sort: "desc",
+      });
+      expect((await app.request("/users?sort=other")).status).toBe(400);
+    },
+  );
+});
+
+describe("validator hooks", () => {
+  it("awaits async validation and returns the hook response without running the handler", async () => {
+    const schema = z4.object({
+      name: z4.string().refine(async (name) => name === "available"),
+    });
+    let handled = false;
+    const app = new Hono().post(
+      "/users",
+      validator("json", schema, async (result, c) => {
+        if (!result.success)
+          return c.json({ message: "Name unavailable" }, 422);
+      }),
+      (c) => {
+        handled = true;
+        return c.json(c.req.valid("json"));
+      },
+    );
+    const request = (name: string) =>
+      app.request("/users", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+    const rejected = await request("taken");
+    expect(rejected.status).toBe(422);
+    expect(await rejected.json()).toEqual({ message: "Name unavailable" });
+    expect(handled).toBe(false);
+    const accepted = await request("available");
+    expect(accepted.status).toBe(200);
+    expect(await accepted.json()).toEqual({ name: "available" });
+    expect(handled).toBe(true);
+  });
+});

--- a/src/__tests__/zodv3.test.ts
+++ b/src/__tests__/zodv3.test.ts
@@ -292,7 +292,7 @@ describe("zod v3", () => {
   it("describeResponse with Date schema matches c.json serialization", async () => {
     const ResponseSchema = z.object({
       name: z.string(),
-      createdAt: z.date(),
+      createdAt: z.date().openapi({ type: "string", format: "date-time" }),
     });
 
     const app = new Hono().get(
@@ -300,7 +300,10 @@ describe("zod v3", () => {
       describeResponse(
         (c) => {
           // Date is JSON-serialized to string by c.json()
-          return c.json({ name: "test", createdAt: new Date() }, 200);
+          return c.json(
+            { name: "test", createdAt: new Date("2026-01-02T03:04:05.000Z") },
+            200,
+          );
         },
         {
           200: {
@@ -315,6 +318,13 @@ describe("zod v3", () => {
       ),
     );
 
+    const response = await app.request("/");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      name: "test",
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+
     const specs = await generateSpecs(app);
 
     expect(specs.paths["/"]?.get?.responses).toEqual({
@@ -322,7 +332,14 @@ describe("zod v3", () => {
         description: "OK",
         content: {
           "application/json": {
-            schema: expect.any(Object),
+            schema: expect.objectContaining({
+              properties: expect.objectContaining({
+                createdAt: expect.objectContaining({
+                  type: "string",
+                  format: "date-time",
+                }),
+              }),
+            }),
           },
         },
       },

--- a/src/__tests__/zodv4.test.ts
+++ b/src/__tests__/zodv4.test.ts
@@ -441,7 +441,7 @@ describe("zod v4", () => {
   it("describeResponse with Date schema matches c.json serialization", async () => {
     const ResponseSchema = z.object({
       name: z.string(),
-      createdAt: z.iso.date(),
+      createdAt: z.iso.datetime(),
     });
 
     const app = new Hono().get(
@@ -451,7 +451,7 @@ describe("zod v4", () => {
           return c.json(
             {
               name: "test",
-              createdAt: new Date(),
+              createdAt: new Date("2026-01-02T03:04:05.000Z"),
             },
             200,
           );
@@ -469,6 +469,13 @@ describe("zod v4", () => {
       ),
     );
 
+    const response = await app.request("/");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      name: "test",
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+
     const specs = await generateSpecs(app);
 
     expect(specs.paths["/"]?.get?.responses).toEqual({
@@ -476,7 +483,14 @@ describe("zod v4", () => {
         description: "OK",
         content: {
           "application/json": {
-            schema: expect.any(Object),
+            schema: expect.objectContaining({
+              properties: expect.objectContaining({
+                createdAt: expect.objectContaining({
+                  type: "string",
+                  format: "date-time",
+                }),
+              }),
+            }),
           },
         },
       },

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -220,6 +220,7 @@ async function generatePaths<
     const { schema: routeSpecs, components = {} } = await getSpec(
       middlewareHandler,
       defaultOptionsForThisMethod,
+      ctx.components.parameters,
     );
 
     ctx.components = mergeComponentsObjects(ctx.components, components);
@@ -261,6 +262,7 @@ function getHiddenValue(options: {
 async function getSpec(
   middlewareHandler: HandlerUniqueProperty,
   defaultOptions?: Partial<DescribeRouteOptions>,
+  parameterComponents?: OpenAPIV3_1.ComponentsObject["parameters"],
 ) {
   // If the middleware handler has a spec, that is decribeRoute middleware
   if ("spec" in middlewareHandler) {
@@ -348,17 +350,25 @@ async function getSpec(
           result.components.schemas,
         );
 
-        if (generatedParameters.length === 1) {
+        const singleParameter =
+          generatedParameters.length === 1 ? generatedParameters[0] : undefined;
+        const existingParameter = parameterComponents?.[pos];
+        if (
+          singleParameter &&
+          (!existingParameter ||
+            ("in" in existingParameter &&
+              existingParameter.in === singleParameter.in &&
+              existingParameter.name === singleParameter.name))
+        ) {
           result.components.parameters ??= {};
-          result.components.parameters[pos] = generatedParameters[0];
+          result.components.parameters[pos] = singleParameter;
 
           // Preserve parameter references for existing single-field schemas.
           parameters.push({ $ref: `#/components/parameters/${pos}` });
           delete result.components.schemas[pos];
         } else {
-          // An object reference cannot name several Parameter Objects. Emit
-          // each field with its own location so reuse across targets cannot
-          // overwrite or deduplicate a field via a shared parameter reference.
+          // A reference cannot name multiple parameters or different locations.
+          // Inline conflicting parameters without overwriting an earlier ref.
           parameters = generatedParameters;
         }
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -342,26 +342,24 @@ async function getSpec(
       if (pos && result.components?.schemas?.[pos]) {
         const schema = result.components.schemas[pos];
 
-        const [firstParameter, ...remainingParameters] = generateParameters(
+        const generatedParameters = generateParameters(
           middlewareHandler.target,
           schema,
           result.components.schemas,
         );
 
-        if (firstParameter) {
+        if (generatedParameters.length === 1) {
           result.components.parameters ??= {};
-          result.components.parameters[pos] = firstParameter;
+          result.components.parameters[pos] = generatedParameters[0];
 
-          // A parameter component describes one field, not the entire object.
-          // Preserve the existing reference for the first field without
-          // dropping the other fields of a named object.
-          parameters.push(
-            {
-              $ref: `#/components/parameters/${pos}`,
-            },
-            ...remainingParameters,
-          );
+          // Preserve parameter references for existing single-field schemas.
+          parameters.push({ $ref: `#/components/parameters/${pos}` });
           delete result.components.schemas[pos];
+        } else {
+          // An object reference cannot name several Parameter Objects. Emit
+          // each field with its own location so reuse across targets cannot
+          // overwrite or deduplicate a field via a shared parameter reference.
+          parameters = generatedParameters;
         }
       }
     } else {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -14,13 +14,13 @@ import type {
   DescribeRouteOptions,
   GenerateSpecOptions,
   HandlerUniqueProperty,
+  RegisterSchemaPathOptions,
   ResponsesWithResolver,
   SpecContext,
 } from "./types";
 import {
   ALLOWED_METHODS,
   type AllowedMethods,
-  clearSpecsContext,
   registerSchemaPath,
   removeExcludedPaths,
   uniqueSymbol,
@@ -115,7 +115,6 @@ export async function generateSpecs<
     ..._documentation,
     components: _documentation.components && { ..._documentation.components },
   };
-  clearSpecsContext();
   const paths = await generatePaths(hono, ctx);
 
   // Hide routes
@@ -174,6 +173,9 @@ async function generatePaths<
   S extends Schema = BlankSchema,
 >(hono: Hono<E, S, P>, ctx: SpecContext): Promise<OpenAPIV3_1.PathsObject> {
   const paths: OpenAPIV3_1.PathsObject = {};
+  // Conversion awaits vendor adapters, so concurrent generations must not
+  // share middleware metadata while traversing their routes.
+  const pathContext = new Map<string, RegisterSchemaPathOptions["specs"]>();
 
   for (const route of hono.routes) {
     const middlewareHandler = findTargetHandler(route.handler)[uniqueSymbol] as
@@ -184,10 +186,13 @@ async function generatePaths<
     if (!middlewareHandler) {
       // Include empty paths, if enabled
       if (ctx.options.includeEmptyPaths) {
-        registerSchemaPath({
-          route,
-          paths,
-        });
+        registerSchemaPath(
+          {
+            route,
+            paths,
+          },
+          pathContext,
+        );
       }
 
       continue;
@@ -219,11 +224,14 @@ async function generatePaths<
 
     ctx.components = mergeComponentsObjects(ctx.components, components);
 
-    registerSchemaPath({
-      route,
-      specs: routeSpecs,
-      paths,
-    });
+    registerSchemaPath(
+      {
+        route,
+        specs: routeSpecs,
+        paths,
+      },
+      pathContext,
+    );
   }
 
   return paths;
@@ -298,9 +306,10 @@ async function getSpec(
     middlewareHandler.target === "json"
   ) {
     const media =
-      (middlewareHandler.options?.media ?? middlewareHandler.target === "json")
+      middlewareHandler.options?.media ??
+      (middlewareHandler.target === "json"
         ? "application/json"
-        : "multipart/form-data";
+        : "multipart/form-data");
     if (
       !docs.requestBody ||
       !("content" in docs.requestBody) ||
@@ -333,22 +342,27 @@ async function getSpec(
       if (pos && result.components?.schemas?.[pos]) {
         const schema = result.components.schemas[pos];
 
-        const newParameters = generateParameters(
+        const [firstParameter, ...remainingParameters] = generateParameters(
           middlewareHandler.target,
           schema,
-        )[0];
+          result.components.schemas,
+        );
 
-        if (!result.components.parameters) {
-          result.components.parameters = {};
+        if (firstParameter) {
+          result.components.parameters ??= {};
+          result.components.parameters[pos] = firstParameter;
+
+          // A parameter component describes one field, not the entire object.
+          // Preserve the existing reference for the first field without
+          // dropping the other fields of a named object.
+          parameters.push(
+            {
+              $ref: `#/components/parameters/${pos}`,
+            },
+            ...remainingParameters,
+          );
+          delete result.components.schemas[pos];
         }
-
-        result.components.parameters[pos] = newParameters;
-
-        delete result.components.schemas[pos];
-
-        parameters.push({
-          $ref: `#/components/parameters/${pos}`,
-        });
       }
     } else {
       parameters = generateParameters(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,10 +101,10 @@ const specsByPathContext = new Map<
   RegisterSchemaPathOptions["specs"]
 >();
 
-function getPathContext(path: string) {
+function getPathContext(path: string, pathContext: typeof specsByPathContext) {
   const context: RegisterSchemaPathOptions["specs"][] = [];
 
-  for (const [key, data] of specsByPathContext) {
+  for (const [key, data] of pathContext) {
     if (!data) continue;
 
     // Strip trailing wildcard (e.g., "/players/*" -> "/players")
@@ -177,11 +177,10 @@ function mergeSpecs(
   );
 }
 
-export function registerSchemaPath({
-  route,
-  specs,
-  paths,
-}: RegisterSchemaPathOptions) {
+export function registerSchemaPath(
+  { route, specs, paths }: RegisterSchemaPathOptions,
+  pathContext = specsByPathContext,
+) {
   const path = toOpenAPIPath(route.path);
   const method = route.method.toLowerCase() as
     | Lowercase<AllowedMethods>
@@ -191,16 +190,16 @@ export function registerSchemaPath({
     if (!specs) return;
 
     // Merging specs with existing ones in the context
-    if (specsByPathContext.has(path)) {
-      const prev = specsByPathContext.get(path) ?? {};
+    if (pathContext.has(path)) {
+      const prev = pathContext.get(path) ?? {};
 
-      specsByPathContext.set(path, mergeSpecs(route, prev, specs));
+      pathContext.set(path, mergeSpecs(route, prev, specs));
     } else {
       // If the specs are not present, we can just set it
-      specsByPathContext.set(path, specs);
+      pathContext.set(path, specs);
     }
   } else {
-    const pathContext = getPathContext(path);
+    const context = getPathContext(path, pathContext);
 
     if (!(path in paths)) {
       paths[path] = {};
@@ -210,7 +209,7 @@ export function registerSchemaPath({
       // @ts-expect-error
       paths[path][method] = mergeSpecs(
         route,
-        ...pathContext,
+        ...context,
         paths[path]?.[method],
         specs,
       );


### PR DESCRIPTION
Adds 32 behavior cases across Zod 3, Zod 4, Valibot, ArkType, Effect, TypeBox and Sury. Real Hono requests check required, optional and nullable fields, validation failures, transformed input, defaults and async hooks. Four existing serialization tests now check response JSON against documented date formats; two redundant default-400 tests are removed. No dependencies or snapshots are added.

The tests protect fixes for ignored request-body media overrides, dropped named-schema fields, parameter collisions when a named object is reused across query and header validators, and middleware metadata leaking between concurrent spec generations. Multi-field and conflicting parameters are emitted inline; existing single-field parameter references are preserved when their name and location agree. Each generation owns its middleware context, while exported helper defaults remain compatible.

Validation: all 106 checks pass, including RPC type checks and isolated package installation; the build and changed-file Biome checks pass. The named-parameter fix also passes a built-package check with reversed validator order, multiple routes and repeated generation. A temporary mutation audit confirmed the retained tests detect six deliberate faults. Full-repository lint has an existing LF/CRLF mismatch in unchanged `package.json`, also reproduced on main.
