### PR TITLE
fix: preserve multiple request body media types

### DIFF
--- a/src/__tests__/generation.test.ts
+++ b/src/__tests__/generation.test.ts
@@ -60,6 +60,64 @@ describe("request body media", () => {
       expect(await response.json()).toEqual({ name: "Ada" });
     },
   );
+
+  it("keeps every media type when a route accepts JSON and form data", async () => {
+    const jsonSchema = z.object({ jsonName: z.string() });
+    const formSchema = z.object({ formName: z.string() });
+    const app = new Hono().post(
+      "/users",
+      validator("json", jsonSchema),
+      validator("form", formSchema),
+      (c) => c.json({ ok: true }),
+    );
+
+    const specs = await generateSpecs(app);
+    const body = specs.paths["/users"]?.post?.requestBody;
+    if (!body || !("content" in body)) {
+      throw new Error("Missing request body");
+    }
+
+    expect(Object.keys(body.content).sort()).toEqual([
+      "application/json",
+      "multipart/form-data",
+    ]);
+    expect(body.content["application/json"].schema).toMatchObject({
+      properties: { jsonName: { type: "string" } },
+    });
+    expect(body.content["multipart/form-data"].schema).toMatchObject({
+      properties: { formName: { type: "string" } },
+    });
+  });
+
+  it("does not combine request body references with inline content", async () => {
+    const reference = { $ref: "#/components/requestBodies/Example" };
+    const jsonValidator = validator("json", z.object({ name: z.string() }));
+    const generateRequestBody = async (
+      ...handlers: Parameters<Hono["post"]>
+    ) => {
+      const app = new Hono().post("/users", ...handlers, (c) =>
+        c.json({ ok: true }),
+      );
+      return (await generateSpecs(app)).paths["/users"]?.post?.requestBody;
+    };
+
+    const referenceThenValidator = await generateRequestBody(
+      describeRoute({ requestBody: reference }),
+      jsonValidator,
+    );
+    expect(referenceThenValidator).toMatchObject({
+      content: {
+        "application/json": expect.any(Object),
+      },
+    });
+    expect(referenceThenValidator).not.toHaveProperty("$ref");
+
+    const validatorThenReference = await generateRequestBody(
+      jsonValidator,
+      describeRoute({ requestBody: reference }),
+    );
+    expect(validatorThenReference).toEqual(reference);
+  });
 });
 
 describe("named parameter schemas", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,6 +125,24 @@ export function clearSpecsContext() {
   specsByPathContext.clear();
 }
 
+function mergeRequestBodies(
+  previous: OpenAPIV3_1.OperationObject["requestBody"],
+  current: OpenAPIV3_1.OperationObject["requestBody"],
+) {
+  if (!previous || !current || "$ref" in previous || "$ref" in current) {
+    return current;
+  }
+
+  return {
+    ...previous,
+    ...current,
+    content: {
+      ...previous.content,
+      ...current.content,
+    },
+  };
+}
+
 function mergeSpecs(
   route: RouterRoute,
   ...specs: RegisterSchemaPathOptions["specs"][]
@@ -157,6 +175,11 @@ function mergeSpecs(
             if (key === "parameters") {
               // @ts-expect-error
               prev[key] = mergeParameters(prev[key], value);
+            } else if (key === "requestBody") {
+              prev.requestBody = mergeRequestBodies(
+                prev.requestBody,
+                value as OpenAPIV3_1.OperationObject["requestBody"],
+              );
             } else {
               prev[key] = {
                 ...prev[key],


### PR DESCRIPTION
When a route used validators for JSON and form data, only the last validator’s request media type appeared in the generated OpenAPI spec.

This merges request-body content by media type and adds a regression test covering both JSON and multipart form data.

Fixes #103